### PR TITLE
chore: skip crates.io for now

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,36 +23,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  publish-dry-run:
-    name: "Runs cargo publish --dry-run"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup Rust Cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Setup Cargo Binstall
-        uses: cargo-bins/cargo-binstall@main
-
-      - name: Install Rust Binaries
-        run: cargo binstall -y --force cargo-tag
-
-      - name: Build (debug)
-        run: cargo b
-
-      - name: publish crate
-        run: |
-          cargo package --list --allow-dirty
-          cargo publish --dry-run --allow-dirty
-
   build-binaries:
     name: Build binaries
-    needs: publish-dry-run
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This pull request simplifies the continuous deployment workflow by removing the `publish-dry-run` job from the `.github/workflows/cd.yml` file. This change streamlines the workflow and eliminates the dependency of the `build-binaries` job on the removed job.

Continuous deployment workflow simplification:

* Removed the entire `publish-dry-run` job, including Rust setup, caching, binary installation, build, and dry-run publish steps from `.github/workflows/cd.yml`.
* Updated the `build-binaries` job to no longer depend on the removed `publish-dry-run` job.