### PR TITLE
fix(cd): alternative `rust-lld` linker for `aarch64-unknown-linux-gnu`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -125,6 +125,12 @@ jobs:
       - name: Install Rust Binaries
         run: cargo binstall -y --force cargo-tag
 
+      - name: Install Linker for ARM64 Linux GNU
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Retrieve Git Commit SHA
         run: echo "GIT_COMMIT_SHA7=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,42 @@ jobs:
 
       - name: Run Tests
         run: cargo test --all-features
+
+  build-binaries:
+    name: Build binaries
+    strategy:
+      matrix:
+        include:
+          - name: linux-x64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: linux-arm64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - name: macos-x64
+            os: macos-latest
+            target: x86_64-apple-darwin
+          - name: macos-arm64
+            os: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Linker for ARM64 Linux GNU
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build binary
+        run: cargo build --target ${{ matrix.target }}


### PR DESCRIPTION
This pull request adds support for cross-compiling to the ARM64 Linux GNU target (`aarch64-unknown-linux-gnu`). The changes ensure the correct linker is configured and that the necessary toolchain is installed in the CI workflow.

**Cross-compilation support for ARM64:**

* Added a `[target.aarch64-unknown-linux-gnu]` section in `.cargo/config.toml` to specify the use of `aarch64-linux-gnu-gcc` as the linker.
* Updated the GitHub Actions workflow in `.github/workflows/cd.yml` to install the `gcc-aarch64-linux-gnu` package when building for the `aarch64-unknown-linux-gnu` target.

Refer to: https://github.com/rust-lang/rust/issues/130062