### PR TITLE
fix(cd): `macos-x86_64` linker issues

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,8 +78,13 @@ jobs:
             echo "CRATE_VERSION=$(cargo tag --no-tag --no-commit -p=v prerelease pre.$GIT_COMMIT_SHA7)" >> $GITHUB_ENV
           fi
 
-      - name: Build binary
+      - name: Build binary specifying target
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build binary
+        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
+        run: cargo build --release
 
       - name: Package binary
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,11 +53,15 @@ jobs:
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install Linker for ARM64 Linux GNU
+      - name: Build for ARM64 Linux GNU
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
+          cargo build --target --release ${{ matrix.target }}
+
+      - name: Build binary
+        run: cargo build --release
 
       - name: Setup Cargo Binstall
         uses: cargo-bins/cargo-binstall@main
@@ -77,14 +81,6 @@ jobs:
           else
             echo "CRATE_VERSION=$(cargo tag --no-tag --no-commit -p=v prerelease pre.$GIT_COMMIT_SHA7)" >> $GITHUB_ENV
           fi
-
-      - name: Build binary specifying target
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        run: cargo build --release --target ${{ matrix.target }}
-
-      - name: Build binary
-        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
-        run: cargo build --release
 
       - name: Package binary
         run: |
@@ -129,12 +125,6 @@ jobs:
 
       - name: Install Rust Binaries
         run: cargo binstall -y --force cargo-tag
-
-      - name: Install Linker for ARM64 Linux GNU
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Retrieve Git Commit SHA
         run: echo "GIT_COMMIT_SHA7=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
-          cargo build --target --release ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }}
 
       - name: Build binary
         if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,6 +80,7 @@ jobs:
           cargo build --target --release ${{ matrix.target }}
 
       - name: Build binary
+        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
         run: cargo build --release
 
       - name: Package binary

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,16 +53,6 @@ jobs:
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Build for ARM64 Linux GNU
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          cargo build --target --release ${{ matrix.target }}
-
-      - name: Build binary
-        run: cargo build --release
-
       - name: Setup Cargo Binstall
         uses: cargo-bins/cargo-binstall@main
 
@@ -81,6 +71,16 @@ jobs:
           else
             echo "CRATE_VERSION=$(cargo tag --no-tag --no-commit -p=v prerelease pre.$GIT_COMMIT_SHA7)" >> $GITHUB_ENV
           fi
+
+      - name: Build for ARM64 Linux GNU
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          cargo build --target --release ${{ matrix.target }}
+
+      - name: Build binary
+        run: cargo build --release
 
       - name: Package binary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
-      - name: Build binary
+      - name: Build binary specifying target
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: cargo build --target ${{ matrix.target }}
+
+      - name: Build binary
+        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
+        run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
-          cargo build --target --release ${{ matrix.target }}
+          cargo build --release --target ${{ matrix.target }}
 
       - name: Build binary
         if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,12 @@ jobs:
       - name: Setup Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install Linker for ARM64 Linux GNU
+      - name: Build for ARM64 Linux GNU
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
-
-      - name: Build binary specifying target
-        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
-        run: cargo build --target ${{ matrix.target }}
+          cargo build --target ${{ matrix.target }}
 
       - name: Build binary
-        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
         run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
-          cargo build --target ${{ matrix.target }}
+          cargo build --target --release ${{ matrix.target }}
 
       - name: Build binary
-        run: cargo build
+        if: ${{ matrix.target != 'aarch64-unknown-linux-gnu' }}
+        run: cargo build --release


### PR DESCRIPTION
This pull request updates the CI/CD GitHub workflow files to streamline and correct the ARM64 Linux GNU build process. The main changes involve consolidating the installation of the ARM64 linker and the build step into a single job, and ensuring that the standard build step does not redundantly specify the target or install the linker unnecessarily.

**CI/CD workflow improvements:**

* Combined the installation of the ARM64 Linux GNU linker and the ARM64 build step into a single job (`Build for ARM64 Linux GNU`) in both `.github/workflows/ci.yml` and `.github/workflows/cd.yml`, reducing redundancy and clarifying the build process. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL58-R66) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R75-R83)
* Removed the separate `Install Linker for ARM64 Linux GNU` job from both workflow files, as it is now handled within the ARM64 build step. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L56-L61) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L128-L133)

**General build step simplification:**

* Updated the standard `Build binary` step to run `cargo build` (without specifying a target), ensuring that the target-specific build is only performed in the dedicated ARM64 step. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL58-R66) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R75-R83)