### PR TITLE
chore(cd): skip `macos-15-intel`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,9 +34,6 @@ jobs:
           - name: linux-arm64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          - name: macos-x64
-            os: macos-15-intel
-            target: x86_64-apple-darwin
           - name: macos-arm64
             os: macos-latest
             target: aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
           - name: linux-arm64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          - name: macos-x64
-            os: macos-latest
-            target: x86_64-apple-darwin
           - name: macos-arm64
             os: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
While the following issue is under investigation.

https://github.com/bytecodealliance/wasmtime/issues/12217
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
