### PR TITLE
feat(executor): implement a executor component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,22 +1166,25 @@ dependencies = [
 
 [[package]]
 name = "mate"
-version = "0.0.0-pre.21b77ae"
+version = "0.0.0-pre.a666fa3"
 dependencies = [
  "anyhow",
- "mate_runner",
+ "bytes",
+ "mate_executor",
  "serde",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
-name = "mate_runner"
-version = "0.0.0-pre.21b77ae"
+name = "mate_executor"
+version = "0.0.0-pre.a666fa3"
 dependencies = [
  "anyhow",
+ "bytes",
  "serde",
  "serde_json",
+ "tokio",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
@@ -1189,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "mate_task"
-version = "0.0.0-pre.21b77ae"
+version = "0.0.0-pre.a666fa3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "mate"
-version = "0.0.0-pre.a666fa3"
+version = "0.0.0-pre.21b77ae"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "mate_executor"
-version = "0.0.0-pre.a666fa3"
+version = "0.0.0-pre.21b77ae"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "mate_task"
-version = "0.0.0-pre.a666fa3"
+version = "0.0.0-pre.21b77ae"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/mate"
 
 [workspace.dependencies]
 anyhow = "1.0"
+bytes = "1.11"
 log = "0.4"
 proc-macro2 = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -26,5 +27,5 @@ wasmtime-wasi-http = "40"
 wit-bindgen = "0.50"
 wstd = "0.6"
 
-mate_runner = { path = "./src/runner" }
+mate_executor = { path = "./src/executor" }
 mate_task = { path = "./src/task" }

--- a/src/executor/Cargo.toml
+++ b/src/executor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mate_runner"
+name = "mate_executor"
 edition.workspace = true
 version.workspace = true
 authors.workspace = true
@@ -7,13 +7,15 @@ description.workspace = true
 documentation.workspace = true
 
 [lib]
-name = "mate_runner"
+name = "mate_executor"
 path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+bytes = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true}
+tokio = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi =  { workspace = true }
 wasmtime-wasi-http = { workspace = true, features = ["component-model-async"] }

--- a/src/executor/src/lib.rs
+++ b/src/executor/src/lib.rs
@@ -1,0 +1,37 @@
+mod runtime;
+
+use anyhow::Result;
+use bytes::Bytes;
+use serde_json::Value;
+
+use self::runtime::wasmtime::WasmtimeRuntime;
+
+pub enum Runtime {
+    Wasm(WasmtimeRuntime),
+}
+
+pub struct Executor {
+    runtime: Runtime,
+}
+
+impl Default for Executor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Executor {
+    pub fn new() -> Self {
+        Self {
+            runtime: Runtime::Wasm(WasmtimeRuntime::new()),
+        }
+    }
+
+    pub async fn run(self, module: Bytes, input: Bytes) -> Result<Value> {
+        match self.runtime {
+            Runtime::Wasm(runtime) => {
+                tokio::spawn(async move { runtime.execute(module, input).await }).await?
+            }
+        }
+    }
+}

--- a/src/executor/src/runtime/mod.rs
+++ b/src/executor/src/runtime/mod.rs
@@ -1,0 +1,1 @@
+pub mod wasmtime;

--- a/src/mate/Cargo.toml
+++ b/src/mate/Cargo.toml
@@ -12,8 +12,9 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+bytes = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true}
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
-mate_runner = { workspace = true }
+mate_executor = { workspace = true }

--- a/src/mate/src/main.rs
+++ b/src/mate/src/main.rs
@@ -1,15 +1,15 @@
 use std::{fs::read, path::Path};
 
 use anyhow::Result;
-
-use mate_runner::WasmRunner;
 use serde_json::Value;
+
+use mate_executor::Executor;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let wasm = Path::new("http.wasm");
     let wasm = read(wasm)?;
-    let runner = WasmRunner::new(wasm);
+    let executor = Executor::new();
     let input = r#"{
         "api_url": "https://httpbin.org/post",
         "data": {
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
         }
     }"#;
 
-    let output: Value = runner.execute(input.as_bytes().to_vec()).await?;
+    let output: Value = executor.run(wasm.into(), input.as_bytes().into()).await?;
 
     println!("📤 Output:");
     println!("{:#?}\n", output);


### PR DESCRIPTION
Introduces `Executor` as the component in charge of executing Tasks.
The executor uses for now `wasmtime` as its only runtime available (and also default).