### PR TITLE
feat: scheduler process

### DIFF
--- a/src/cli/src/cli/cmd/mod.rs
+++ b/src/cli/src/cli/cmd/mod.rs
@@ -1,9 +1,12 @@
 pub mod hub;
+pub mod scheduler;
 pub mod storage;
 pub mod task;
 
 use anyhow::Result;
 use clap::Parser;
+
+use crate::cli::cmd::scheduler::SchedulerCmd;
 
 use self::hub::HubCmd;
 use self::storage::StorageCmd;
@@ -14,6 +17,9 @@ pub enum Cmd {
     /// Hub management
     #[clap(subcommand)]
     Hub(HubCmd),
+    /// Scheduler management
+    #[clap(subcommand)]
+    Scheduler(SchedulerCmd),
     /// Storage management
     #[clap(subcommand)]
     Storage(StorageCmd),
@@ -26,6 +32,7 @@ impl Cmd {
     pub async fn exec(&self) -> Result<()> {
         match &self {
             Cmd::Hub(cmd) => cmd.exec().await,
+            Cmd::Scheduler(cmd) => cmd.exec().await,
             Cmd::Storage(cmd) => cmd.exec().await,
             Cmd::Task(cmd) => cmd.exec().await,
         }

--- a/src/cli/src/cli/cmd/scheduler.rs
+++ b/src/cli/src/cli/cmd/scheduler.rs
@@ -1,0 +1,19 @@
+mod spawn;
+
+use anyhow::Result;
+use clap::Parser;
+
+use self::spawn::SchedulerSpawnOpt;
+
+#[derive(Debug, Parser)]
+pub enum SchedulerCmd {
+    Spawn(SchedulerSpawnOpt),
+}
+
+impl SchedulerCmd {
+    pub async fn exec(&self) -> Result<()> {
+        match &self {
+            SchedulerCmd::Spawn(cmd) => cmd.exec().await,
+        }
+    }
+}

--- a/src/cli/src/cli/cmd/scheduler/spawn.rs
+++ b/src/cli/src/cli/cmd/scheduler/spawn.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+
+use mate_config::Config;
+use mate_ipc::protocol::ProcessType;
+use tracing::info;
+
+use crate::process::scheduler::SchedulerProcess;
+use crate::transport::make_transport;
+
+#[derive(Debug, Parser)]
+pub struct SchedulerSpawnOpt {
+    #[clap(long, short)]
+    config: PathBuf,
+}
+
+impl SchedulerSpawnOpt {
+    pub async fn exec(&self) -> Result<()> {
+        let config = Config::from_file(&self.config)?;
+        let transport = make_transport(config.clone(), ProcessType::Scheduler).await?;
+        let mut scheduler = SchedulerProcess::new(transport, 1).await?;
+
+        info!("Starting scheduler process…");
+        scheduler.run().await?;
+
+        Ok(())
+    }
+}

--- a/src/cli/src/process.rs
+++ b/src/cli/src/process.rs
@@ -1,2 +1,3 @@
 pub mod hub;
+pub mod scheduler;
 pub mod storage;

--- a/src/cli/src/process/hub.rs
+++ b/src/cli/src/process/hub.rs
@@ -4,11 +4,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use mate_config::Config;
-use mate_ipc::channel::IpcServer;
-use mate_ipc::protocol::{Message, ProcessType};
 use tokio::process::{Child, Command};
 use tokio::time::sleep;
+
+use mate_config::Config;
+use mate_ipc::channel::IpcServer;
+use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 
 use crate::transport::make_transport;
 
@@ -49,6 +50,15 @@ impl Hub {
 
         child_processes.push(storage);
 
+        let scheduler = Command::new(&mate_exe)
+            .arg("scheduler")
+            .arg("spawn")
+            .arg("--config")
+            .arg(self.config_path.to_str().unwrap())
+            .spawn()?;
+
+        child_processes.push(scheduler);
+
         // TODO: Perform Polling via Transport perhaps?
         sleep(Duration::from_secs(1)).await;
 
@@ -60,11 +70,22 @@ impl Hub {
             .request(Message::new(
                 ProcessType::Hub,
                 ProcessType::Storage,
-                mate_ipc::protocol::MessagePayload::Ping,
+                MessagePayload::Ping,
             ))
             .await?;
 
         println!("✓ Storage OK!");
+
+        self.ipc
+            .request(Message::new(
+                ProcessType::Hub,
+                ProcessType::Scheduler,
+                MessagePayload::Ping,
+            ))
+            .await?;
+
+        println!("✓ Scheduler OK!");
+
         Ok(())
     }
 

--- a/src/cli/src/process/hub.rs
+++ b/src/cli/src/process/hub.rs
@@ -13,6 +13,8 @@ use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 
 use crate::transport::make_transport;
 
+const IPC_SENDER_HUB: ProcessType = ProcessType::Hub;
+
 pub struct Hub {
     config: Config,
     config_path: PathBuf,
@@ -22,8 +24,8 @@ pub struct Hub {
 impl Hub {
     pub async fn new(config_path: PathBuf) -> Result<Self> {
         let config = Config::from_file(&config_path)?;
-        let transport = make_transport(config.clone(), ProcessType::Hub).await?;
-        let ipc = IpcServer::new(ProcessType::Hub, transport);
+        let transport = make_transport(config.clone(), IPC_SENDER_HUB).await?;
+        let ipc = IpcServer::new(IPC_SENDER_HUB, transport);
         let ipc = Arc::new(ipc);
 
         Ok(Self {
@@ -68,7 +70,7 @@ impl Hub {
     pub async fn wait_for_components(&self) -> Result<()> {
         self.ipc
             .request(Message::new(
-                ProcessType::Hub,
+                IPC_SENDER_HUB,
                 ProcessType::Storage,
                 MessagePayload::Ping,
             ))
@@ -78,7 +80,7 @@ impl Hub {
 
         self.ipc
             .request(Message::new(
-                ProcessType::Hub,
+                IPC_SENDER_HUB,
                 ProcessType::Scheduler,
                 MessagePayload::Ping,
             ))

--- a/src/cli/src/process/scheduler.rs
+++ b/src/cli/src/process/scheduler.rs
@@ -11,6 +11,8 @@ use mate_ipc::channel::IpcServer;
 use mate_ipc::protocol::{Job, JobStatus, Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
 
+const IPC_SENDER_SCHEDULER: ProcessType = ProcessType::Scheduler;
+
 pub struct SchedulerProcess {
     ipc: Arc<IpcServer>,
     executor_count: usize,
@@ -19,7 +21,7 @@ pub struct SchedulerProcess {
 
 impl SchedulerProcess {
     pub async fn new(transport: Box<dyn Transport>, executor_count: usize) -> Result<Self> {
-        let ipc = Arc::new(IpcServer::new(ProcessType::Scheduler, transport));
+        let ipc = Arc::new(IpcServer::new(IPC_SENDER_SCHEDULER, transport));
 
         Ok(Self {
             ipc,
@@ -54,7 +56,7 @@ impl SchedulerProcess {
         // Query storage for Scheduled jobs
         let query_msg = Message {
             id: Uuid::new_v4(),
-            from: ProcessType::Scheduler,
+            from: IPC_SENDER_SCHEDULER,
             to: ProcessType::Storage,
             payload: MessagePayload::QueryScheduledJobs(SystemTime::now()),
             reply_to: None,
@@ -85,7 +87,7 @@ impl SchedulerProcess {
         let job_id = job.id;
 
         let msg = Message::new(
-            ProcessType::Scheduler,
+            IPC_SENDER_SCHEDULER,
             ProcessType::Executor(executor_id),
             MessagePayload::ExecuteJob(job),
         );
@@ -97,7 +99,7 @@ impl SchedulerProcess {
         if let Err(err) = self
             .ipc
             .send(Message::new(
-                ProcessType::Scheduler,
+                IPC_SENDER_SCHEDULER,
                 ProcessType::Storage,
                 MessagePayload::UpdateJobStatus(job_id, JobStatus::Pending),
             ))

--- a/src/cli/src/process/scheduler.rs
+++ b/src/cli/src/process/scheduler.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use tokio::sync::Mutex;
 use tokio::time::interval;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use mate_ipc::channel::IpcServer;
-use mate_ipc::protocol::{Job, Message, MessagePayload, ProcessType};
+use mate_ipc::protocol::{Job, JobStatus, Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
 
 pub struct SchedulerProcess {
@@ -66,7 +66,9 @@ impl SchedulerProcess {
 
         if let MessagePayload::JobsResult(jobs) = response.payload {
             for job in jobs {
-                self.dispatch_job(job).await?;
+                if let Err(err) = self.dispatch_job(job).await {
+                    warn!(?err, "Failed to dispatch job");
+                }
             }
         }
 
@@ -80,6 +82,7 @@ impl SchedulerProcess {
         let executor_id = *current_executor;
         *current_executor = (*current_executor + 1) % self.executor_count;
         drop(current_executor);
+        let job_id = job.id;
 
         let msg = Message::new(
             ProcessType::Scheduler,
@@ -87,8 +90,23 @@ impl SchedulerProcess {
             MessagePayload::ExecuteJob(job),
         );
 
-        if let Err(err) = self.ipc.request(msg).await {
-            warn!(?err, "Failed te send message");
+        if let Err(err) = self.ipc.send(msg).await {
+            bail!("Failed to send message to dispatch job via IPC. {:?}", err);
+        }
+
+        if let Err(err) = self
+            .ipc
+            .send(Message::new(
+                ProcessType::Scheduler,
+                ProcessType::Storage,
+                MessagePayload::UpdateJobStatus(job_id, JobStatus::Pending),
+            ))
+            .await
+        {
+            error!(
+                ?err,
+                "Failed to send message to Storage in order to update Job status"
+            );
         }
 
         Ok(())
@@ -112,7 +130,7 @@ impl SchedulerProcess {
 
                 if let Err(err) = self.ipc.send(response_msg).await {
                     eprintln!(
-                        "Error while sending message from Storage to IPC. {:#?}",
+                        "Error while sending message from Scheduler to IPC. {:#?}",
                         err
                     );
                 }

--- a/src/cli/src/process/scheduler.rs
+++ b/src/cli/src/process/scheduler.rs
@@ -51,12 +51,12 @@ impl SchedulerProcess {
     }
 
     async fn check_and_schedule_jobs(&self) -> Result<()> {
-        // Query storage for pending jobs
+        // Query storage for Scheduled jobs
         let query_msg = Message {
             id: Uuid::new_v4(),
             from: ProcessType::Scheduler,
             to: ProcessType::Storage,
-            payload: MessagePayload::QueryPendingJobs(SystemTime::now()),
+            payload: MessagePayload::QueryScheduledJobs(SystemTime::now()),
             reply_to: None,
         };
 

--- a/src/cli/src/process/scheduler.rs
+++ b/src/cli/src/process/scheduler.rs
@@ -19,7 +19,7 @@ pub struct SchedulerProcess {
 
 impl SchedulerProcess {
     pub async fn new(transport: Box<dyn Transport>, executor_count: usize) -> Result<Self> {
-        let ipc = Arc::new(IpcServer::new(ProcessType::Storage, transport));
+        let ipc = Arc::new(IpcServer::new(ProcessType::Scheduler, transport));
 
         Ok(Self {
             ipc,

--- a/src/cli/src/process/scheduler.rs
+++ b/src/cli/src/process/scheduler.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+use tokio::sync::Mutex;
+use tokio::time::interval;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use mate_ipc::channel::IpcServer;
+use mate_ipc::protocol::{Job, Message, MessagePayload, ProcessType};
+use mate_ipc::transport::Transport;
+
+pub struct SchedulerProcess {
+    ipc: Arc<IpcServer>,
+    executor_count: usize,
+    current_executor: Mutex<usize>,
+}
+
+impl SchedulerProcess {
+    pub async fn new(transport: Box<dyn Transport>, executor_count: usize) -> Result<Self> {
+        let ipc = Arc::new(IpcServer::new(ProcessType::Storage, transport));
+
+        Ok(Self {
+            ipc,
+            executor_count,
+            current_executor: Mutex::new(0),
+        })
+    }
+
+    pub async fn run(&mut self) -> Result<()> {
+        tokio::select! {
+            Err(err) = self.clock() => {
+                error!(?err, "Scheduler clock failed.");
+            }
+            Err(err) = self.message_consumer() => {
+                error!(?err, "Scheduler message consumer failed.");
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn clock(&self) -> Result<()> {
+        let mut interval = interval(Duration::from_secs(1));
+
+        loop {
+            interval.tick().await;
+            self.check_and_schedule_jobs().await?;
+        }
+    }
+
+    async fn check_and_schedule_jobs(&self) -> Result<()> {
+        // Query storage for pending jobs
+        let query_msg = Message {
+            id: Uuid::new_v4(),
+            from: ProcessType::Scheduler,
+            to: ProcessType::Storage,
+            payload: MessagePayload::QueryPendingJobs(SystemTime::now()),
+            reply_to: None,
+        };
+
+        let response = self.ipc.request(query_msg).await?;
+
+        info!(?response, "Got response in scheduler");
+
+        if let MessagePayload::JobsResult(jobs) = response.payload {
+            for job in jobs {
+                self.dispatch_job(job).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Dispatch Jobs by performing Round-Robin distribution on available
+    /// executor processes and sending a [`Message`] to the next executor.
+    async fn dispatch_job(&self, job: Job) -> Result<()> {
+        let mut current_executor = self.current_executor.lock().await;
+        let executor_id = *current_executor;
+        *current_executor = (*current_executor + 1) % self.executor_count;
+        drop(current_executor);
+
+        let msg = Message::new(
+            ProcessType::Scheduler,
+            ProcessType::Executor(executor_id),
+            MessagePayload::ExecuteJob(job),
+        );
+
+        if let Err(err) = self.ipc.request(msg).await {
+            warn!(?err, "Failed te send message");
+        }
+
+        Ok(())
+    }
+
+    async fn message_consumer(&self) -> Result<()> {
+        let ipc_clone = Arc::clone(&self.ipc);
+
+        tokio::spawn(async move {
+            let _ = ipc_clone.listen().await;
+        });
+
+        let rx = self.ipc.receiver().await;
+        let mut rx = rx.lock().await;
+
+        while let Some(msg) = rx.recv().await {
+            if let Some(response) = self.handle_message(msg.clone()).await {
+                let response_msg = Message::new(ProcessType::Storage, msg.from, response)
+                    .reply_to(msg.id)
+                    .to_owned();
+
+                if let Err(err) = self.ipc.send(response_msg).await {
+                    eprintln!(
+                        "Error while sending message from Storage to IPC. {:#?}",
+                        err
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_message(&self, msg: Message) -> Option<MessagePayload> {
+        match msg.payload {
+            MessagePayload::Ping => Some(MessagePayload::Pong),
+            MessagePayload::Shutdown => Some(MessagePayload::ShutdownAck),
+            _ => None,
+        }
+    }
+}

--- a/src/cli/src/process/storage.rs
+++ b/src/cli/src/process/storage.rs
@@ -75,7 +75,7 @@ impl StorageProcess {
                     .collect();
                 Some(MessagePayload::JobsResult(jobs))
             }
-            MessagePayload::QueryPendingJobs(sys_time) => {
+            MessagePayload::QueryScheduledJobs(sys_time) => {
                 let jobs: Vec<Job> = self
                     .jobs
                     .values()

--- a/src/cli/src/process/storage.rs
+++ b/src/cli/src/process/storage.rs
@@ -8,6 +8,8 @@ use mate_ipc::channel::IpcServer;
 use mate_ipc::protocol::{Job, JobStatus, Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
 
+const IPC_SENDER_STORAGE: ProcessType = ProcessType::Storage;
+
 pub struct StorageProcess {
     ipc: Arc<IpcServer>,
     jobs: HashMap<Uuid, Job>,
@@ -15,7 +17,7 @@ pub struct StorageProcess {
 
 impl StorageProcess {
     pub fn new(transport: Box<dyn Transport>) -> Self {
-        let ipc = Arc::new(IpcServer::new(ProcessType::Storage, transport));
+        let ipc = Arc::new(IpcServer::new(IPC_SENDER_STORAGE, transport));
 
         Self {
             jobs: HashMap::new(),
@@ -43,7 +45,7 @@ impl StorageProcess {
 
         while let Some(msg) = rx.recv().await {
             if let Some(response) = self.handle_message(msg.clone()).await {
-                let response_msg = Message::new(ProcessType::Storage, msg.from, response)
+                let response_msg = Message::new(IPC_SENDER_STORAGE, msg.from, response)
                     .reply_to(msg.id)
                     .to_owned();
 

--- a/src/cli/src/process/storage.rs
+++ b/src/cli/src/process/storage.rs
@@ -5,7 +5,7 @@ use anyhow::{Result, bail};
 use uuid::Uuid;
 
 use mate_ipc::channel::IpcServer;
-use mate_ipc::protocol::{Job, Message, MessagePayload, ProcessType};
+use mate_ipc::protocol::{Job, JobStatus, Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
 
 pub struct StorageProcess {
@@ -71,6 +71,16 @@ impl StorageProcess {
                     .jobs
                     .values()
                     .filter(|j| query.status.as_ref().is_none_or(|s| &j.status == s))
+                    .cloned()
+                    .collect();
+                Some(MessagePayload::JobsResult(jobs))
+            }
+            MessagePayload::QueryPendingJobs(sys_time) => {
+                let jobs: Vec<Job> = self
+                    .jobs
+                    .values()
+                    .filter(|j| j.status == JobStatus::Scheduled)
+                    .filter(|j| j.scheduled_at <= sys_time)
                     .cloned()
                     .collect();
                 Some(MessagePayload::JobsResult(jobs))

--- a/src/cli/src/server/api/v0/jobs/create.rs
+++ b/src/cli/src/server/api/v0/jobs/create.rs
@@ -31,7 +31,7 @@ pub async fn handler(
         id: Uuid::new_v4(),
         name: job_data.name,
         payload: job_data.payload,
-        status: JobStatus::Pending,
+        status: JobStatus::Scheduled,
         scheduled_at: SystemTime::now(),
         started_at: None,
         completed_at: None,

--- a/src/ipc/src/protocol.rs
+++ b/src/ipc/src/protocol.rs
@@ -54,7 +54,7 @@ pub enum MessagePayload {
     JobUpdated(Result<(), String>),
 
     // Scheduler -> Storage
-    QueryPendingJobs(SystemTime),
+    QueryScheduledJobs(SystemTime),
 
     // Scheduler -> Executor
     ExecuteJob(Job),


### PR DESCRIPTION
This pull request introduces a new scheduler process to the CLI application, enabling job scheduling and dispatching to executor processes. The changes add a new `scheduler` command to the CLI, implement the logic for spawning and running the scheduler, and integrate it with the hub and storage processes to support round-robin job distribution. Additionally, the storage process now supports querying for scheduled jobs, and job creation sets jobs as scheduled by default.

**Scheduler Process Integration**

* Added a new `scheduler` command to the CLI, with support for spawning and executing the scheduler process via `SchedulerCmd` and `SchedulerSpawnOpt`. (`src/cli/src/cli/cmd/mod.rs`, `src/cli/src/cli/cmd/scheduler.rs`, `src/cli/src/cli/cmd/scheduler/spawn.rs`) [[1]](diffhunk://#diff-62235516070cdb721dadab0c4cb7a2d6a536f35dd70f1edcb80e91786f7290eeR2-R10) [[2]](diffhunk://#diff-62235516070cdb721dadab0c4cb7a2d6a536f35dd70f1edcb80e91786f7290eeR20-R22) [[3]](diffhunk://#diff-62235516070cdb721dadab0c4cb7a2d6a536f35dd70f1edcb80e91786f7290eeR35) [[4]](diffhunk://#diff-2d6bdc9d6d233028d8a784221c91591edeb9dc8668151aa39060d2d105314cccR1-R19) [[5]](diffhunk://#diff-a13cc41ba1467fa971b9196e31865c73a3128b655ab92de325a21863f74910f2R1-R30)
* Implemented the `SchedulerProcess` struct, which periodically queries storage for scheduled jobs and dispatches them to executor processes using round-robin distribution. (`src/cli/src/process/scheduler.rs`)

**Hub Process Updates**

* Updated the hub process to spawn the scheduler as a child process and added health checks to ensure the scheduler is running and responsive. (`src/cli/src/process/hub.rs`) [[1]](diffhunk://#diff-4c4de190d4d619f6ec11589426cae4edffd0ec9a091b6d648094ab5d35860ccbR53-R61) [[2]](diffhunk://#diff-4c4de190d4d619f6ec11589426cae4edffd0ec9a091b6d648094ab5d35860ccbL63-R88)

**Storage Process Enhancements**

* Added support in the storage process for responding to `QueryPendingJobs` messages, returning jobs that are scheduled and ready to run. (`src/cli/src/process/storage.rs`) [[1]](diffhunk://#diff-fbf0785270d61445d425b59b5a60c4e4b2db087f653e83e28c0b4ea292a8ea95L8-R8) [[2]](diffhunk://#diff-fbf0785270d61445d425b59b5a60c4e4b2db087f653e83e28c0b4ea292a8ea95R78-R87)

**Job Creation Behavior**

* Changed job creation to set the initial status of new jobs to `Scheduled` instead of `Pending`, aligning with the new scheduler flow. (`src/cli/src/server/api/v0/jobs/create.rs`)