### PR TITLE
feat: support job creation from cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +205,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -272,7 +300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -314,10 +342,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -360,6 +400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +422,36 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -632,6 +711,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,7 +938,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "debugid",
  "rustc-hash",
  "serde",
@@ -872,8 +963,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -883,9 +976,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1021,19 +1116,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1175,7 +1296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
  "bitmaps",
- "rand_core",
+ "rand_core 0.6.4",
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
@@ -1245,6 +1366,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1415,28 @@ checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -1341,7 +1494,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -1370,6 +1523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,17 +1554,26 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mate"
-version = "0.0.0-pre.8f2717a"
+version = "0.0.0-pre.a0ef495"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "uuid",
+]
 
 [[package]]
 name = "mate-cli"
-version = "0.0.0-pre.8f2717a"
+version = "0.0.0-pre.a0ef495"
 dependencies = [
  "anyhow",
  "axum",
  "bytes",
  "clap",
  "include_dir",
+ "mate",
  "mate-config",
  "mate-executor",
  "mate-ipc",
@@ -1420,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "mate-config"
-version = "0.0.0-pre.8f2717a"
+version = "0.0.0-pre.a0ef495"
 dependencies = [
  "anyhow",
  "serde",
@@ -1429,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "mate-executor"
-version = "0.0.0-pre.8f2717a"
+version = "0.0.0-pre.a0ef495"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1444,10 +1612,12 @@ dependencies = [
 
 [[package]]
 name = "mate-ipc"
-version = "0.0.0-pre.8f2717a"
+version = "0.0.0-pre.a0ef495"
 dependencies = [
  "anyhow",
  "async-trait",
+ "mate",
+ "mate-repository",
  "serde",
  "serde_json",
  "tempfile",
@@ -1457,18 +1627,20 @@ dependencies = [
 
 [[package]]
 name = "mate-repository"
-version = "0.0.0-pre.8f2717a"
+version = "0.0.0-pre.a0ef495"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "mate",
  "semver",
+ "serde",
  "tokio",
 ]
 
 [[package]]
 name = "mate-task"
-version = "0.0.0-pre.8f2717a"
+version = "0.0.0-pre.a0ef495"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1548,6 +1720,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking"
@@ -1662,6 +1840,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,8 +1917,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1694,7 +1938,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1707,12 +1961,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1778,6 +2041,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,7 +2112,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1822,7 +2125,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -1848,9 +2151,35 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1859,8 +2188,36 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.9",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1868,6 +2225,18 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1884,6 +2253,47 @@ name = "ryu"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2099,6 +2509,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2112,12 +2525,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-interface"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -2215,6 +2649,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,8 +2696,18 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls",
+ "rustls 0.22.4",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.36",
  "tokio",
 ]
 
@@ -2318,6 +2777,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2491,6 +2968,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,6 +3012,19 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2618,7 +3118,7 @@ version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2631,7 +3131,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2657,7 +3157,7 @@ dependencies = [
  "addr2line",
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 2.10.0",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -2904,7 +3404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c92d907d4c1e9b6a04698eabb07ee2a8937ecebc700dfc3395ba43a849046c9"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.10.0",
  "heck",
  "indexmap",
  "wit-parser 0.243.0",
@@ -2918,7 +3418,7 @@ checksum = "6304c1efccc38e36181d9e43203a7afeeaba76de88e15f8136242e35a33aba88"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
@@ -2955,9 +3455,9 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "rustls",
+ "rustls 0.22.4",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
@@ -3010,6 +3510,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,7 +3563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7dfe611d0640dd6076b39eb80a0e29ea8bb09f77d8b58c03401d3a496c6624"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.10.0",
  "thiserror 2.0.17",
  "tracing",
  "wasmtime",
@@ -3160,6 +3689,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,6 +3715,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3215,6 +3764,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -3248,6 +3812,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3260,6 +3830,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3269,6 +3845,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3296,6 +3878,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3305,6 +3893,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3320,6 +3914,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3329,6 +3929,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3354,7 +3960,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3364,7 +3970,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -3373,7 +3979,7 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "wit-bindgen-rust-macro",
 ]
 
@@ -3426,7 +4032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.10.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mate"
-version = "0.0.0-pre.a0ef495"
+version = "0.0.0-pre.8f2717a"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "mate-cli"
-version = "0.0.0-pre.a0ef495"
+version = "0.0.0-pre.8f2717a"
 dependencies = [
  "anyhow",
  "axum",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "mate-config"
-version = "0.0.0-pre.a0ef495"
+version = "0.0.0-pre.8f2717a"
 dependencies = [
  "anyhow",
  "serde",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "mate-executor"
-version = "0.0.0-pre.a0ef495"
+version = "0.0.0-pre.8f2717a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "mate-ipc"
-version = "0.0.0-pre.a0ef495"
+version = "0.0.0-pre.8f2717a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "mate-repository"
-version = "0.0.0-pre.a0ef495"
+version = "0.0.0-pre.8f2717a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "mate-task"
-version = "0.0.0-pre.a0ef495"
+version = "0.0.0-pre.8f2717a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = "4.5"
 include_dir = "0.7"
 log = "0.4"
 proc-macro2 = "1.0"
+reqwest = "0.13"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }
 
+mate = { workspace = true }
 mate-config = { workspace = true }
 mate-executor = { workspace = true }
 mate-ipc = { workspace = true }

--- a/src/cli/src/cli/cmd.rs
+++ b/src/cli/src/cli/cmd.rs
@@ -1,5 +1,6 @@
 pub mod executor;
 pub mod hub;
+pub mod job;
 pub mod scheduler;
 pub mod storage;
 pub mod task;
@@ -8,6 +9,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::cli::cmd::executor::ExecutorCmd;
+use crate::cli::cmd::job::JobCmd;
 use crate::cli::cmd::scheduler::SchedulerCmd;
 
 use self::hub::HubCmd;
@@ -22,6 +24,9 @@ pub enum Cmd {
     /// Hub management
     #[clap(subcommand)]
     Hub(HubCmd),
+    /// Job management
+    #[clap(subcommand)]
+    Job(JobCmd),
     /// Scheduler management
     #[clap(subcommand)]
     Scheduler(SchedulerCmd),
@@ -38,6 +43,7 @@ impl Cmd {
         match &self {
             Cmd::Executor(cmd) => cmd.exec().await,
             Cmd::Hub(cmd) => cmd.exec().await,
+            Cmd::Job(cmd) => cmd.exec().await,
             Cmd::Scheduler(cmd) => cmd.exec().await,
             Cmd::Storage(cmd) => cmd.exec().await,
             Cmd::Task(cmd) => cmd.exec().await,

--- a/src/cli/src/cli/cmd/job.rs
+++ b/src/cli/src/cli/cmd/job.rs
@@ -1,0 +1,26 @@
+mod list;
+mod new;
+
+use anyhow::Result;
+use clap::Parser;
+
+use self::list::JobListOpt;
+use self::new::JobNewOpt;
+
+#[derive(Debug, Parser)]
+pub enum JobCmd {
+    /// Creates a new Job
+    New(JobNewOpt),
+    /// Lists existing Jobs
+    #[clap(alias = "ls")]
+    List(JobListOpt),
+}
+
+impl JobCmd {
+    pub async fn exec(&self) -> Result<()> {
+        match &self {
+            JobCmd::New(cmd) => cmd.exec().await,
+            JobCmd::List(cmd) => cmd.exec().await,
+        }
+    }
+}

--- a/src/cli/src/cli/cmd/job/list.rs
+++ b/src/cli/src/cli/cmd/job/list.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use clap::Parser;
+
+use mate::Client;
+
+#[derive(Debug, Parser)]
+pub struct JobListOpt {}
+
+impl JobListOpt {
+    pub async fn exec(&self) -> Result<()> {
+        let client = Client::new("http://localhost:8080".to_string());
+
+        match client.retrieve_jobs().await {
+            Ok(jobs) => {
+                for job in jobs {
+                    println!("{:?}", job);
+                }
+            }
+            Err(e) => {
+                println!("Failed to list jobs: {}", e);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/src/cli/cmd/job/new.rs
+++ b/src/cli/src/cli/cmd/job/new.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use clap::Parser;
+use serde_json::Value;
+
+use mate::{Client, proto::task::TaskIdentifier};
+
+#[derive(Debug, Parser)]
+pub struct JobNewOpt {
+    /// Name of the job
+    #[clap(long, short)]
+    pub name: String,
+    /// Payload for the job in JSON format
+    #[clap(long, short)]
+    pub payload: Value,
+    /// Task to execute this job with
+    #[clap(long, short)]
+    pub task: TaskIdentifier,
+}
+
+impl JobNewOpt {
+    pub async fn exec(&self) -> Result<()> {
+        let client = Client::new("http://localhost:8080".to_string());
+
+        match client
+            .create_job(self.name.clone(), self.task.clone(), self.payload.clone())
+            .await
+        {
+            Ok(job) => {
+                println!("Job created successfully: {:?}", job);
+            }
+            Err(e) => {
+                println!("Failed to create job: {}", e);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/src/cli/cmd/task/load.rs
+++ b/src/cli/src/cli/cmd/task/load.rs
@@ -2,9 +2,10 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-
-use mate_repository::{TaskRepository, id::TaskIdentifier};
 use tokio::fs::read;
+
+use mate::proto::task::TaskIdentifier;
+use mate_repository::TaskRepository;
 
 #[derive(Debug, Parser)]
 pub struct TaskLoadOpt {

--- a/src/cli/src/cli/cmd/task/new.rs
+++ b/src/cli/src/cli/cmd/task/new.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use include_dir::{Dir, File, include_dir};
 
-use mate_repository::id::TaskIdentifier;
+use mate::proto::task::TaskIdentifier;
 
 static ASSETS_TASK_RUST: Dir = include_dir!("$CARGO_MANIFEST_DIR/assets/task/rust");
 

--- a/src/cli/src/process/executor.rs
+++ b/src/cli/src/process/executor.rs
@@ -3,14 +3,15 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
 use bytes::Bytes;
-use mate_config::Config;
 use tokio::fs;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 
+use mate::proto::job::{Job, JobResult};
+use mate_config::Config;
 use mate_executor::Executor;
 use mate_ipc::channel::IpcServer;
-use mate_ipc::protocol::{Job, JobResult, Message, MessagePayload, ProcessType};
+use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
 
 pub struct ExecutorProcess {
@@ -84,10 +85,10 @@ impl ExecutorProcess {
         let job_id = job.id;
         let payload = job.payload.clone();
         let process_type = self.process_type();
-        let task = match self.get_or_load_module(&task_name).await {
+        let task = match self.get_or_load_module(&task_name.to_string()).await {
             Ok(m) => m,
             Err(err) => {
-                error!(?err, task_name, "Failed to load WASM Task");
+                error!(?err, ?task_name, "Failed to load WASM Task");
 
                 if let Err(err) = ipc
                     .request(Message::new(

--- a/src/cli/src/process/scheduler.rs
+++ b/src/cli/src/process/scheduler.rs
@@ -7,8 +7,9 @@ use tokio::time::interval;
 use tracing::{error, warn};
 use uuid::Uuid;
 
+use mate::proto::job::{Job, JobStatus};
 use mate_ipc::channel::IpcServer;
-use mate_ipc::protocol::{Job, JobStatus, Message, MessagePayload, ProcessType};
+use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
 
 const IPC_SENDER_SCHEDULER: ProcessType = ProcessType::Scheduler;

--- a/src/cli/src/process/storage.rs
+++ b/src/cli/src/process/storage.rs
@@ -6,8 +6,9 @@ use anyhow::{Result, bail};
 use tracing::debug;
 use uuid::Uuid;
 
+use mate::proto::job::{Job, JobStatus};
 use mate_ipc::channel::IpcServer;
-use mate_ipc::protocol::{Job, JobStatus, Message, MessagePayload, ProcessType};
+use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
 
 const IPC_SENDER_STORAGE: ProcessType = ProcessType::Storage;

--- a/src/cli/src/server/api/v0/jobs/create.rs
+++ b/src/cli/src/server/api/v0/jobs/create.rs
@@ -1,11 +1,14 @@
+use std::str::FromStr;
 use std::time::SystemTime;
 
 use axum::http::StatusCode;
 use axum::{Extension, Json};
+use mate::proto::task::TaskIdentifier;
 use serde::Deserialize;
 use uuid::Uuid;
 
-use mate_ipc::protocol::{Job, JobStatus, Message, MessagePayload, ProcessType};
+use mate::proto::job::{Job, JobStatus};
+use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 
 use crate::server::api::v0::ApiError;
 use crate::server::state::SharedServices;
@@ -20,7 +23,12 @@ pub struct CreateJobRequest {
 pub async fn handler(
     Extension(services): Extension<SharedServices>,
     Json(job_data): Json<CreateJobRequest>,
-) -> Result<Json<Message>, ApiError> {
+) -> Result<Json<Job>, ApiError> {
+    let task = TaskIdentifier::from_str(&job_data.task).map_err(|_| ApiError {
+        message: String::from("Invalid task identifier format"),
+        status: StatusCode::BAD_REQUEST,
+    })?;
+
     if job_data.name.is_empty() || job_data.name.contains(' ') {
         return Err(ApiError {
             message: String::from("Job name cannot contain spaces and cannot be empty"),
@@ -46,7 +54,7 @@ pub async fn handler(
         result: None,
         retry_count: 0,
         max_retries: 3,
-        task: job_data.task,
+        task,
     };
     let msg = Message::new(
         ProcessType::Hub,
@@ -64,5 +72,15 @@ pub async fn handler(
             message: err,
         })?;
 
-    Ok(Json(message))
+    match message.payload {
+        MessagePayload::JobStored(Ok(job)) => Ok(Json(job)),
+        MessagePayload::JobStored(Err(message)) => Err(ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message,
+        }),
+        _ => Err(ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: String::from("Unexpected response from storage service"),
+        }),
+    }
 }

--- a/src/cli/src/server/api/v0/jobs/retrieve.rs
+++ b/src/cli/src/server/api/v0/jobs/retrieve.rs
@@ -4,7 +4,8 @@ use axum::{Extension, Json};
 use serde::Deserialize;
 use uuid::Uuid;
 
-use mate_ipc::protocol::{Job, JobQuery, JobStatus, Message, MessagePayload, ProcessType};
+use mate::proto::job::{Job, JobQuery, JobStatus};
+use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 
 use crate::server::api::v0::ApiError;
 use crate::server::state::SharedServices;

--- a/src/ipc/Cargo.toml
+++ b/src/ipc/Cargo.toml
@@ -18,3 +18,6 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt", "sync", "time"] }
 uuid = { workspace = true, features = ["serde", "v4"] }
+
+mate = { workspace = true }
+mate-repository = { workspace = true }

--- a/src/ipc/src/protocol.rs
+++ b/src/ipc/src/protocol.rs
@@ -1,46 +1,11 @@
 use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use uuid::Uuid;
 
+use mate::proto::job::{Job, JobQuery, JobResult, JobStatus};
+
 pub type ExecutorId = usize;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Job {
-    pub id: Uuid,
-    pub name: String,
-    pub payload: Value,
-    pub status: JobStatus,
-    pub scheduled_at: SystemTime,
-    pub task: String,
-    pub started_at: Option<SystemTime>,
-    pub completed_at: Option<SystemTime>,
-    pub result: Option<JobResult>,
-    pub retry_count: u32,
-    pub max_retries: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum JobStatus {
-    Pending,
-    Scheduled,
-    Running,
-    Completed,
-    Failed,
-    Cancelled,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum JobResult {
-    Success(serde_json::Value),
-    Failure(String),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct JobQuery {
-    pub status: Option<JobStatus>,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MessagePayload {

--- a/src/mate/Cargo.toml
+++ b/src/mate/Cargo.toml
@@ -9,3 +9,11 @@ documentation.workspace = true
 [lib]
 name = "mate"
 path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+semver = { workspace = true }
+uuid = { workspace = true }

--- a/src/mate/src/lib.rs
+++ b/src/mate/src/lib.rs
@@ -1,1 +1,97 @@
+//! Mate Client
+//!
+//! ```ignore
+//! use mate::JobClient;
+//!
+//! let client = JobClient::new("http://localhost:3000".to_string());
+//! let payload = serde_json::json!({
+//!     "data": "example"
+//! });
+//!
+//! let message = client
+//!     .create_job(
+//!         "my-job".to_string(),
+//!         "task::identifier".to_string(),
+//!         payload,
+//!     )
+//!     .await?;
+//!
+//! println!("Created job: {:?}", message);
+//! Ok(())
+//! ```
 
+pub mod proto;
+
+use anyhow::{Result, bail};
+use reqwest::Client as HttpClient;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::proto::job::Job;
+use crate::proto::task::TaskIdentifier;
+
+#[derive(Debug, Serialize)]
+struct CreateJobRequest {
+    name: String,
+    task: String,
+    payload: Value,
+}
+
+pub struct Client {
+    client: HttpClient,
+    base_url: String,
+}
+
+impl Client {
+    pub fn new(base_url: String) -> Self {
+        Self {
+            client: HttpClient::new(),
+            base_url,
+        }
+    }
+
+    pub async fn create_job(
+        &self,
+        name: String,
+        task: TaskIdentifier,
+        payload: Value,
+    ) -> Result<Job> {
+        let task = task.to_string();
+        let request = CreateJobRequest {
+            name,
+            task,
+            payload,
+        };
+
+        let response = self
+            .client
+            .post(format!("{}/api/v0/jobs", self.base_url)) // Adjust the path as needed
+            .json(&request)
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            let message = response.json::<Job>().await?;
+            return Ok(message);
+        }
+
+        let status = response.status();
+        let error_text = response.text().await?;
+
+        bail!("Request failed with status {}: {}", status, error_text)
+    }
+
+    pub async fn retrieve_jobs(&self) -> Result<Vec<Job>> {
+        let request = self.client.get(format!("{}/api/v0/jobs", self.base_url));
+        let response = request.send().await?;
+
+        if response.status().is_success() {
+            let jobs = response.json::<Vec<Job>>().await?;
+            return Ok(jobs);
+        }
+        let status = response.status();
+        let error_text = response.text().await?;
+
+        bail!("Request failed with status {}: {}", status, error_text)
+    }
+}

--- a/src/mate/src/proto.rs
+++ b/src/mate/src/proto.rs
@@ -1,0 +1,2 @@
+pub mod job;
+pub mod task;

--- a/src/mate/src/proto/job.rs
+++ b/src/mate/src/proto/job.rs
@@ -1,0 +1,45 @@
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::proto::task::TaskIdentifier;
+
+pub type ExecutorId = usize;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Job {
+    pub id: Uuid,
+    pub name: String,
+    pub payload: Value,
+    pub status: JobStatus,
+    pub scheduled_at: SystemTime,
+    pub task: TaskIdentifier,
+    pub started_at: Option<SystemTime>,
+    pub completed_at: Option<SystemTime>,
+    pub result: Option<JobResult>,
+    pub retry_count: u32,
+    pub max_retries: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum JobStatus {
+    Pending,
+    Scheduled,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum JobResult {
+    Success(serde_json::Value),
+    Failure(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobQuery {
+    pub status: Option<JobStatus>,
+}

--- a/src/mate/src/proto/task.rs
+++ b/src/mate/src/proto/task.rs
@@ -1,9 +1,10 @@
 use std::{fmt::Display, str::FromStr};
 
-use anyhow::{Error, Result, bail};
+use anyhow::{Error, bail};
 use semver::Version;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TaskIdentifier {
     pub namespace: String,
     pub name: String,

--- a/src/repository/Cargo.toml
+++ b/src/repository/Cargo.toml
@@ -14,5 +14,8 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 semver = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-std", "io-util"] }
+
+mate = { workspace = true }

--- a/src/repository/src/backend.rs
+++ b/src/repository/src/backend.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use crate::id::TaskIdentifier;
+use mate::proto::task::TaskIdentifier;
 
 #[async_trait]
 pub trait Backend {

--- a/src/repository/src/backend/local.rs
+++ b/src/repository/src/backend/local.rs
@@ -8,7 +8,9 @@ use bytes::Bytes;
 use tokio::fs::{File, create_dir_all, read, read_dir};
 use tokio::io::AsyncWriteExt;
 
-use crate::{backend::Backend, id::TaskIdentifier};
+use mate::proto::task::TaskIdentifier;
+
+use crate::backend::Backend;
 
 pub struct LocalBackend {
     dir: PathBuf,

--- a/src/repository/src/lib.rs
+++ b/src/repository/src/lib.rs
@@ -1,13 +1,11 @@
 pub mod backend;
-pub mod id;
 
 use anyhow::Result;
 use bytes::Bytes;
 
-use crate::{
-    backend::{Backend, LocalBackend},
-    id::TaskIdentifier,
-};
+use mate::proto::task::TaskIdentifier;
+
+use crate::backend::{Backend, LocalBackend};
 
 pub struct TaskRepository {
     backend: Box<dyn Backend>,


### PR DESCRIPTION
Provides support using `TaskIdentifier` as part of the  Job creation.
Job creation can now be performed via CLI.