### PR TITLE
feat: support to load tasks from repository

### DIFF
--- a/src/cli/src/cli/cmd/executor/spawn.rs
+++ b/src/cli/src/cli/cmd/executor/spawn.rs
@@ -22,7 +22,7 @@ impl ExecutorSpawnOpt {
     pub async fn exec(&self) -> Result<()> {
         let config = Config::from_file(&self.config)?;
         let transport = make_transport(config.clone(), ProcessType::Executor(self.id)).await?;
-        let mut executor = ExecutorProcess::new(transport, config, self.id)?;
+        let mut executor = ExecutorProcess::new(transport, self.id).await?;
 
         info!(id=%self.id, "Starting executor process…");
         executor.run().await?;

--- a/src/cli/src/cli/cmd/job/new.rs
+++ b/src/cli/src/cli/cmd/job/new.rs
@@ -4,13 +4,15 @@ use serde_json::Value;
 
 use mate::{Client, proto::task::TaskIdentifier};
 
+use crate::cli::utils::io::parse_json;
+
 #[derive(Debug, Parser)]
 pub struct JobNewOpt {
     /// Name of the job
     #[clap(long, short)]
     pub name: String,
     /// Payload for the job in JSON format
-    #[clap(long, short)]
+    #[clap(long, short, value_parser = parse_json)]
     pub payload: Value,
     /// Task to execute this job with
     #[clap(long, short)]
@@ -20,6 +22,8 @@ pub struct JobNewOpt {
 impl JobNewOpt {
     pub async fn exec(&self) -> Result<()> {
         let client = Client::new("http://localhost:8080".to_string());
+
+        println!("{:?}", self.payload);
 
         match client
             .create_job(self.name.clone(), self.task.clone(), self.payload.clone())

--- a/src/cli/src/cli/cmd/task/run.rs
+++ b/src/cli/src/cli/cmd/task/run.rs
@@ -22,9 +22,9 @@ impl TaskRunOpt {
         serde_json::from_str::<Value>(&self.args)
             .context("Failed to deserialize string into JSON")?;
 
-        let source = self.source.clone();
         let args = self.args.clone();
         let args = args.as_bytes().to_vec();
+        let source = self.source.clone();
         let wasm = read(source)?;
         let executor = Executor::new();
         let output: Value = executor.run(wasm.into(), args.into()).await?;

--- a/src/cli/src/cli/mod.rs
+++ b/src/cli/src/cli/mod.rs
@@ -1,4 +1,5 @@
 mod cmd;
+mod utils;
 
 use anyhow::Result;
 use clap::Parser;

--- a/src/cli/src/cli/utils.rs
+++ b/src/cli/src/cli/utils.rs
@@ -1,0 +1,1 @@
+pub mod io;

--- a/src/cli/src/cli/utils/io.rs
+++ b/src/cli/src/cli/utils/io.rs
@@ -1,0 +1,44 @@
+use std::fs::read_to_string;
+use std::io::{Read, stdin};
+
+use anyhow::{Result, anyhow};
+use serde_json::Value;
+
+/// Clap parser to allow parsing stdin, file or direct JSON input.
+///
+/// # Direct (if shell cooperates)
+///
+/// ```ignore
+/// -x '{"hello":"world"}'
+/// ```
+///
+/// # From file
+///
+/// ```ignore
+/// -x @data.json
+/// ```
+///
+/// # From stdin
+///
+/// ```ignore
+/// echo '{"hello":"world"}' | bin -x -
+/// ```
+pub fn parse_json(s: &str) -> Result<Value> {
+    if s == "-" {
+        let mut buffer = String::new();
+        stdin()
+            .read_to_string(&mut buffer)
+            .map_err(|e| anyhow!("Failed to read stdin: {}", e))?;
+        return serde_json::from_str(&buffer)
+            .map_err(|e| anyhow!("Invalid JSON from stdin: {}", e));
+    }
+
+    if let Some(path) = s.strip_prefix('@') {
+        let content =
+            read_to_string(path).map_err(|e| anyhow!("Failed to read file {}: {}", path, e))?;
+        return serde_json::from_str(&content)
+            .map_err(|e| anyhow!("Invalid JSON in file {}: {}", path, e));
+    }
+
+    serde_json::from_str(s).map_err(|e| anyhow!("Invalid JSON: {}", e))
+}

--- a/src/cli/src/process/executor.rs
+++ b/src/cli/src/process/executor.rs
@@ -3,37 +3,38 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
 use bytes::Bytes;
-use tokio::fs;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 
 use mate::proto::job::{Job, JobResult};
-use mate_config::Config;
+use mate::proto::task::TaskIdentifier;
 use mate_executor::Executor;
 use mate_ipc::channel::IpcServer;
 use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
+use mate_repository::TaskRepository;
 
 pub struct ExecutorProcess {
     id: usize,
     ipc: Arc<IpcServer>,
     executor: Arc<Executor>,
-    modules: Arc<RwLock<HashMap<String, Bytes>>>,
-    config: Config,
+    repository: TaskRepository,
+    cache: Arc<RwLock<HashMap<TaskIdentifier, Bytes>>>,
 }
 
 impl ExecutorProcess {
-    pub fn new(transport: Box<dyn Transport>, config: Config, id: usize) -> Result<Self> {
-        let modules = Arc::new(RwLock::new(HashMap::new()));
+    pub async fn new(transport: Box<dyn Transport>, id: usize) -> Result<Self> {
+        let cache = Arc::new(RwLock::new(HashMap::new()));
         let executor = Arc::new(Executor::new());
+        let repository = TaskRepository::local().await?;
         let ipc = Arc::new(IpcServer::new(ProcessType::Executor(id), transport));
 
         Ok(Self {
             id,
             ipc,
             executor,
-            modules,
-            config,
+            repository,
+            cache,
         })
     }
 
@@ -46,49 +47,50 @@ impl ExecutorProcess {
     }
 
     /// Load module on-demand with caching
-    async fn get_or_load_module(&self, task_name: &str) -> Result<Bytes> {
+    async fn get_or_load_module(&self, tid: &TaskIdentifier) -> Result<Bytes> {
         {
-            let modules = self.modules.read().await;
+            let cache = self.cache.read().await;
 
-            if let Some(module) = modules.get(task_name) {
+            if let Some(module) = cache.get(tid) {
                 return Ok(module.clone());
             }
         }
 
-        info!(task_name, "Loading WASM module");
+        info!(?tid, "Loading WASM module from repository");
 
-        let path = self
-            .config
-            .registry
-            .path
-            .join(format!("{}.wasm", task_name));
-        let wasm = fs::read(&path)
+        let task_bytes = self
+            .repository
+            .find(tid)
             .await
-            .context(format!("Failed to read WASM file: {:?}", path))?;
-        let wasm: Bytes = wasm.into();
-        let cached_wasm = {
-            let mut modules = self.modules.write().await;
-            modules
-                .entry(task_name.to_string())
-                .or_insert_with(|| wasm.clone())
-                .clone()
-        };
-        info!(task_name, "WASM module loaded and cached");
+            .context(format!("Failed to find Task in repository: {}", tid))?;
 
-        Ok(cached_wasm)
+        if let Some(wasm) = task_bytes {
+            let cached_wasm = {
+                let mut cache = self.cache.write().await;
+                cache
+                    .entry(tid.clone())
+                    .or_insert_with(|| wasm.clone())
+                    .clone()
+            };
+
+            info!(?tid, "WASM module loaded and cached");
+            return Ok(cached_wasm);
+        }
+
+        bail!("Task not found in repository: {}", tid);
     }
 
     pub async fn execute(&self, job: Job) -> Result<()> {
         let ipc = Arc::clone(&self.ipc);
         let executor = Arc::clone(&self.executor);
-        let task_name = job.task.clone();
+        let tid = job.task.clone();
         let job_id = job.id;
         let payload = job.payload.clone();
         let process_type = self.process_type();
-        let task = match self.get_or_load_module(&task_name.to_string()).await {
+        let task = match self.get_or_load_module(&tid).await {
             Ok(m) => m,
             Err(err) => {
-                error!(?err, ?task_name, "Failed to load WASM Task");
+                error!(?err, ?tid, "Failed to load WASM Task");
 
                 if let Err(err) = ipc
                     .request(Message::new(
@@ -111,10 +113,9 @@ impl ExecutorProcess {
         let payload_bytes: Bytes = serde_json::to_vec(&payload)?.into();
 
         tokio::spawn(async move {
-            info!(%job_id, %task_name, "Executing Job");
+            info!(%job_id, %tid, "Executing Job");
 
             let result = executor.run(task, payload_bytes).await;
-
             let job_result = match result {
                 Ok(output) => {
                     info!(%job_id, ?output, "Job completed successfully");

--- a/src/cli/src/process/storage.rs
+++ b/src/cli/src/process/storage.rs
@@ -6,7 +6,7 @@ use anyhow::{Result, bail};
 use tracing::debug;
 use uuid::Uuid;
 
-use mate::proto::job::{Job, JobStatus};
+use mate::proto::job::{Job, JobResult, JobStatus};
 use mate_ipc::channel::IpcServer;
 use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
@@ -71,8 +71,23 @@ impl StorageProcess {
 
                 if let Some(job) = self.jobs.get_mut(&id) {
                     job.completed_at = Some(SystemTime::now());
+
+                    match &result {
+                        JobResult::Success(_) => {
+                            job.status = JobStatus::Completed;
+                        }
+                        JobResult::Failure(err) => {
+                            if job.retry_count < job.max_retries {
+                                job.status = JobStatus::Scheduled;
+                                job.retry_count += 1;
+                                job.errors.push(err.to_string());
+                            } else {
+                                job.status = JobStatus::Failed;
+                            }
+                        }
+                    }
+
                     job.result = Some(result);
-                    job.status = JobStatus::Completed;
 
                     return Some(MessagePayload::JobStored(Ok(job.clone())));
                 }

--- a/src/cli/src/server/api/v0/jobs/create.rs
+++ b/src/cli/src/server/api/v0/jobs/create.rs
@@ -5,6 +5,7 @@ use axum::http::StatusCode;
 use axum::{Extension, Json};
 use mate::proto::task::TaskIdentifier;
 use serde::Deserialize;
+use serde_json::Value;
 use uuid::Uuid;
 
 use mate::proto::job::{Job, JobStatus};
@@ -17,7 +18,7 @@ use crate::server::state::SharedServices;
 pub struct CreateJobRequest {
     name: String,
     task: String,
-    payload: serde_json::Value,
+    payload: Value,
 }
 
 pub async fn handler(
@@ -55,6 +56,7 @@ pub async fn handler(
         retry_count: 0,
         max_retries: 3,
         task,
+        errors: Vec::new(),
     };
     let msg = Message::new(
         ProcessType::Hub,

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod executor;
 pub mod hub;
-pub mod registry;
 pub mod scheduler;
 pub mod storage;
 pub mod transport;
@@ -13,7 +12,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::executor::ExecutorConfig;
 use crate::hub::HubConfig;
-use crate::registry::RegistryConfig;
 use crate::scheduler::SchedulerConfig;
 use crate::storage::StorageConfig;
 use crate::transport::TransportConfig;
@@ -25,7 +23,6 @@ pub struct Config {
     pub storage: StorageConfig,
     pub scheduler: SchedulerConfig,
     pub executors: ExecutorConfig,
-    pub registry: RegistryConfig,
 }
 
 impl Config {
@@ -64,9 +61,6 @@ mod test {
             [executors]
             count = 2
             max_concurrent_jobs = 5
-
-            [registry]
-            path = "./reg"
             "#;
 
         let config = Config::from_toml(config_toml);

--- a/src/config/src/registry.rs
+++ b/src/config/src/registry.rs
@@ -1,8 +1,0 @@
-use std::path::PathBuf;
-
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct RegistryConfig {
-    pub path: PathBuf,
-}

--- a/src/mate/src/proto/job.rs
+++ b/src/mate/src/proto/job.rs
@@ -18,6 +18,7 @@ pub struct Job {
     pub task: TaskIdentifier,
     pub started_at: Option<SystemTime>,
     pub completed_at: Option<SystemTime>,
+    pub errors: Vec<String>,
     pub result: Option<JobResult>,
     pub retry_count: u32,
     pub max_retries: u32,
@@ -35,7 +36,7 @@ pub enum JobStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum JobResult {
-    Success(serde_json::Value),
+    Success(Value),
     Failure(String),
 }
 

--- a/src/repository/src/backend.rs
+++ b/src/repository/src/backend.rs
@@ -11,6 +11,6 @@ use mate::proto::task::TaskIdentifier;
 #[async_trait]
 pub trait Backend {
     async fn create(&self, id: &TaskIdentifier, bytes: Bytes) -> Result<()>;
-    async fn retrieve(&self, id: &TaskIdentifier) -> Result<Option<Bytes>>;
+    async fn find(&self, id: &TaskIdentifier) -> Result<Option<Bytes>>;
     async fn list(&self) -> Result<Vec<TaskIdentifier>>;
 }

--- a/src/repository/src/backend/local.rs
+++ b/src/repository/src/backend/local.rs
@@ -61,7 +61,7 @@ impl Backend for LocalBackend {
         Ok(())
     }
 
-    async fn retrieve(&self, id: &TaskIdentifier) -> Result<Option<Bytes>> {
+    async fn find(&self, id: &TaskIdentifier) -> Result<Option<Bytes>> {
         let file_path = self
             .dir
             .join(&id.namespace)

--- a/src/repository/src/lib.rs
+++ b/src/repository/src/lib.rs
@@ -25,4 +25,8 @@ impl TaskRepository {
     pub async fn store(&self, id: &TaskIdentifier, data: Bytes) -> Result<()> {
         self.backend.create(id, data).await
     }
+
+    pub async fn find(&self, id: &TaskIdentifier) -> Result<Option<Bytes>> {
+        self.backend.find(id).await
+    }
 }


### PR DESCRIPTION
Executor will now load tasks from the Local Repository.
To introduce tasks, a user must first present the task as:

```bash
mate task new                # create task dir
cd ./<proj> && cargo b       # builds the task dir
mate task load ./target/release/<proj>.wasm --name <name>
```

Then creates its job to be executed in the future:

```bash
mate job new
```