### PR TITLE
feat(cli): render table for `job`/`task`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1586,7 @@ dependencies = [
  "mate-repository",
  "serde",
  "serde_json",
+ "tabled",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1728,6 +1735,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +1822,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -2562,6 +2602,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2587,6 +2651,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
+tabled = "0.20"
 tempfile = "3.24"
 tokio = "1"
 toml = "0.9"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -17,7 +17,8 @@ bytes = { workspace = true }
 clap = { workspace = true, features = ["env", "derive", "std"] }
 include_dir = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true}
+serde_json = { workspace = true }
+tabled = { workspace = true }
 tokio = { workspace = true, features = ["macros", "process", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/src/cli/src/cli/cmd/job/list.rs
+++ b/src/cli/src/cli/cmd/job/list.rs
@@ -17,19 +17,6 @@ struct JobListItem {
     retries: String,
 }
 
-// pub id: Uuid,
-// pub name: String,
-// pub payload: Value,
-// pub status: JobStatus,
-// pub scheduled_at: SystemTime,
-// pub task: TaskIdentifier,
-// pub started_at: Option<SystemTime>,
-// pub completed_at: Option<SystemTime>,
-// pub errors: Vec<String>,
-// pub result: Option<JobResult>,
-// pub retry_count: u32,
-// pub max_retries: u32,
-
 #[derive(Debug, Parser)]
 pub struct JobListOpt {}
 

--- a/src/cli/src/cli/cmd/job/list.rs
+++ b/src/cli/src/cli/cmd/job/list.rs
@@ -1,7 +1,34 @@
 use anyhow::Result;
 use clap::Parser;
+use tabled::Tabled;
 
 use mate::Client;
+use uuid::Uuid;
+
+use crate::cli::utils::display::print_table;
+
+#[derive(Tabled)]
+struct JobListItem {
+    id: Uuid,
+    name: String,
+    status: String,
+    task: String,
+    result: String,
+    retries: String,
+}
+
+// pub id: Uuid,
+// pub name: String,
+// pub payload: Value,
+// pub status: JobStatus,
+// pub scheduled_at: SystemTime,
+// pub task: TaskIdentifier,
+// pub started_at: Option<SystemTime>,
+// pub completed_at: Option<SystemTime>,
+// pub errors: Vec<String>,
+// pub result: Option<JobResult>,
+// pub retry_count: u32,
+// pub max_retries: u32,
 
 #[derive(Debug, Parser)]
 pub struct JobListOpt {}
@@ -12,9 +39,22 @@ impl JobListOpt {
 
         match client.retrieve_jobs().await {
             Ok(jobs) => {
-                for job in jobs {
-                    println!("{:?}", job);
-                }
+                let data = jobs
+                    .into_iter()
+                    .map(|job| JobListItem {
+                        id: job.id,
+                        name: job.name,
+                        status: format!("{}", job.status),
+                        task: format!("{}", job.task),
+                        result: match &job.result {
+                            Some(res) => format!("{}", res),
+                            None => "N/A".to_string(),
+                        },
+                        retries: format!("{}/{}", job.retry_count, job.max_retries),
+                    })
+                    .collect::<Vec<JobListItem>>();
+
+                print_table(data);
             }
             Err(e) => {
                 println!("Failed to list jobs: {}", e);

--- a/src/cli/src/cli/cmd/job/new.rs
+++ b/src/cli/src/cli/cmd/job/new.rs
@@ -23,14 +23,12 @@ impl JobNewOpt {
     pub async fn exec(&self) -> Result<()> {
         let client = Client::new("http://localhost:8080".to_string());
 
-        println!("{:?}", self.payload);
-
         match client
             .create_job(self.name.clone(), self.task.clone(), self.payload.clone())
             .await
         {
             Ok(job) => {
-                println!("Job created successfully: {:?}", job);
+                println!("Job created successfully. ID: {:?}", job.id);
             }
             Err(e) => {
                 println!("Failed to create job: {}", e);

--- a/src/cli/src/cli/cmd/task.rs
+++ b/src/cli/src/cli/cmd/task.rs
@@ -1,3 +1,4 @@
+mod list;
 mod load;
 mod new;
 mod run;
@@ -5,16 +6,20 @@ mod run;
 use anyhow::Result;
 use clap::Parser;
 
+use self::list::TaskListOpt;
 use self::load::TaskLoadOpt;
 use self::new::TaskNewOpt;
 use self::run::TaskRunOpt;
 
 #[derive(Debug, Parser)]
 pub enum TaskCmd {
-    /// Create a new Task project
-    New(TaskNewOpt),
+    /// Lists existing Tasks in the Local Repository
+    #[clap(alias = "ls")]
+    List(TaskListOpt),
     /// Loads a Task to the Local Repository so its found by Executors
     Load(TaskLoadOpt),
+    /// Create a new Task project
+    New(TaskNewOpt),
     /// Run a task passing arguments and retrieves results
     Run(TaskRunOpt),
 }
@@ -22,8 +27,9 @@ pub enum TaskCmd {
 impl TaskCmd {
     pub async fn exec(&self) -> Result<()> {
         match &self {
-            TaskCmd::New(cmd) => cmd.exec().await,
+            TaskCmd::List(cmd) => cmd.exec().await,
             TaskCmd::Load(cmd) => cmd.exec().await,
+            TaskCmd::New(cmd) => cmd.exec().await,
             TaskCmd::Run(cmd) => cmd.exec().await,
         }
     }

--- a/src/cli/src/cli/cmd/task/list.rs
+++ b/src/cli/src/cli/cmd/task/list.rs
@@ -1,7 +1,17 @@
 use anyhow::Result;
 use clap::Parser;
+use tabled::Tabled;
 
 use mate_repository::TaskRepository;
+
+use crate::cli::utils::display::print_table;
+
+#[derive(Tabled)]
+struct TaskListItem {
+    namespace: String,
+    name: String,
+    version: String,
+}
 
 #[derive(Debug, Parser)]
 pub struct TaskListOpt {}
@@ -10,11 +20,16 @@ impl TaskListOpt {
     pub async fn exec(&self) -> Result<()> {
         let repo = TaskRepository::local().await?;
         let tasks = repo.list().await?;
+        let tasks: Vec<TaskListItem> = tasks
+            .into_iter()
+            .map(|task| TaskListItem {
+                namespace: task.namespace,
+                name: task.name,
+                version: task.version.to_string(),
+            })
+            .collect();
 
-        for task in tasks {
-            println!("{}", task);
-        }
-
+        print_table(tasks);
         Ok(())
     }
 }

--- a/src/cli/src/cli/cmd/task/list.rs
+++ b/src/cli/src/cli/cmd/task/list.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use clap::Parser;
+
+use mate_repository::TaskRepository;
+
+#[derive(Debug, Parser)]
+pub struct TaskListOpt {}
+
+impl TaskListOpt {
+    pub async fn exec(&self) -> Result<()> {
+        let repo = TaskRepository::local().await?;
+        let tasks = repo.list().await?;
+
+        for task in tasks {
+            println!("{}", task);
+        }
+
+        Ok(())
+    }
+}

--- a/src/cli/src/cli/utils.rs
+++ b/src/cli/src/cli/utils.rs
@@ -1,1 +1,2 @@
+pub mod display;
 pub mod io;

--- a/src/cli/src/cli/utils/display.rs
+++ b/src/cli/src/cli/utils/display.rs
@@ -1,0 +1,7 @@
+use tabled::settings::Style;
+use tabled::{Table, Tabled};
+
+pub fn print_table<T: Tabled>(data: Vec<T>) {
+    let table = Table::new(data).with(Style::modern()).to_string();
+    println!("{table}");
+}

--- a/src/mate/src/proto/job.rs
+++ b/src/mate/src/proto/job.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::{fmt::Display, time::SystemTime};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -34,10 +34,33 @@ pub enum JobStatus {
     Cancelled,
 }
 
+impl Display for JobStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let status_str = match self {
+            JobStatus::Pending => "Pending",
+            JobStatus::Scheduled => "Scheduled",
+            JobStatus::Running => "Running",
+            JobStatus::Completed => "Completed",
+            JobStatus::Failed => "Failed",
+            JobStatus::Cancelled => "Cancelled",
+        };
+        write!(f, "{}", status_str)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum JobResult {
     Success(Value),
     Failure(String),
+}
+
+impl Display for JobResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JobResult::Success(_) => write!(f, "Success"),
+            JobResult::Failure(_) => write!(f, "Failure"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/repository/src/backend/local.rs
+++ b/src/repository/src/backend/local.rs
@@ -90,7 +90,7 @@ impl Backend for LocalBackend {
         {
             let namespace_path = namespace_entry.path();
             if namespace_path.is_dir() {
-                let Some(_namespace) = namespace_path.file_name().and_then(|n| n.to_str()) else {
+                let Some(namespace) = namespace_path.file_name().and_then(|n| n.to_str()) else {
                     bail!(
                         "Failed to retrieve namespace while reading through dir. {namespace_path:?}"
                     );
@@ -112,7 +112,7 @@ impl Backend for LocalBackend {
                     if let Some(file_name) = task_path.file_name().and_then(|n| n.to_str())
                         && let Some((name_version, _)) = file_name.split_once(".wasm")
                     {
-                        match TaskIdentifier::from_str(name_version) {
+                        match TaskIdentifier::from_str(&format!("{namespace}/{}", name_version)) {
                             Ok(id) => {
                                 tasks.push(id);
                             }

--- a/src/repository/src/lib.rs
+++ b/src/repository/src/lib.rs
@@ -29,4 +29,8 @@ impl TaskRepository {
     pub async fn find(&self, id: &TaskIdentifier) -> Result<Option<Bytes>> {
         self.backend.find(id).await
     }
+
+    pub async fn list(&self) -> Result<Vec<TaskIdentifier>> {
+        self.backend.list().await
+    }
 }


### PR DESCRIPTION
Users can now list Job/Tasks via CLI.

```
mate job ls
┌──────────────────────────────────────┬───────┬───────────┬────────────────┬─────────┬─────────┐
│ id                                   │ name  │ status    │ task           │ result  │ retries │
├──────────────────────────────────────┼───────┼───────────┼────────────────┼─────────┼─────────┤
│ 71b5a6fe-b2b4-4235-97d0-046bc867ea64 │ greet │ Completed │ leo/http@0.1.0 │ Success │ 0/3     │
└──────────────────────────────────────┴───────┴───────────┴────────────────┴─────────┴─────────┘
```

```
mate task ls
┌───────────┬──────┬─────────┐
│ namespace │ name │ version │
├───────────┼──────┼─────────┤
│ leo       │ http │ 0.1.0   │
└───────────┴──────┴─────────┘
```