### PR TITLE
feat: provide a docker image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -170,3 +170,63 @@ jobs:
               done
             fi
           done
+
+  docker:
+    name: Publish Docker Image
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Git Fetch Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Setup Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-musl
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup Rust Target
+        run: rustup target add x86_64-unknown-linux-musl
+
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.12.0
+
+      - name: Setup Cargo Binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Setup Binaries
+        run: |
+          cargo binstall -y --force cargo-zigbuild
+          cargo binstall -y --force just
+
+      - name: Install Build Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            pkg-config \
+            libssl-dev
+
+      - name: Build Image
+        run: just docker-build-image
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Image to GitHub Container Registry
+        run: just docker-publish-image

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,8 @@
+set positional-arguments
+
+latest_tag := `cargo tag current`
+target_release := "x86_64-unknown-linux-musl"
+
 default:
     @echo "No default task defined."
     just --list
@@ -7,3 +12,30 @@ build-task task:
     rm ./{{task}}.wasm || true
     cd ./task/{{task}} && cargo +nightly build --release --target wasm32-wasip2
     mv ./target/wasm32-wasip2/release/{{task}}.wasm ./{{task}}.wasm
+
+# Builds the Server binary used in the Docker Image
+docker-build:
+    cargo zigbuild --target {{target_release}} --release --bin mate
+
+# Builds the Docker image
+docker-build-image: docker-build
+    mkdir -p ./docker/tmp/
+    cp ./docs/config/local.toml ./docker/tmp/local.toml
+    cp ./target/{{target_release}}/release/mate ./docker/tmp/mate
+    chmod +x ./docker/tmp/mate
+    docker build -t "mate:{{latest_tag}}" ./docker
+
+# Publishes the Docker image to the GitHub Container Registry
+docker-publish-image:
+    docker tag mate:{{latest_tag}} ghcr.io/leoborai/mate:{{latest_tag}}
+    docker tag mate:{{latest_tag}} ghcr.io/leoborai/mate:latest
+    docker push ghcr.io/leoborai/mate:{{latest_tag}}
+    docker push ghcr.io/leoborai/mate:latest
+
+# Runs the Docker image locally
+docker-run-image: docker-build-image
+    docker run mate:{{latest_tag}}
+
+# Echo latest tag
+latest-tag:
+    echo {{latest_tag}}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3
+
+COPY ./tmp/mate /opt/mate
+
+COPY ./tmp/local.toml /opt/local.toml
+
+ENTRYPOINT ["/opt/mate", "hub", "start", "--config", "./local.toml"]


### PR DESCRIPTION
This pull request introduces a new workflow for building and publishing Docker images for the project, along with supporting changes to the build system and Docker configuration. The main change is the automation of Docker image creation and publication to the GitHub Container Registry, making it easier to distribute and deploy the application.

**CI/CD Workflow Enhancements:**

- Added a new `docker` job to `.github/workflows/cd.yml` that builds the server binary, assembles the Docker image, and publishes it to the GitHub Container Registry as part of the release pipeline.

**Build System Improvements:**

- Updated the `Justfile` to include new tasks for building the server binary for Docker, assembling the Docker image, publishing it to the registry, and running the image locally. Also added support for positional arguments and variables to streamline these tasks. [[1]](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR1-R5) [[2]](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR15-R41)

**Docker Configuration:**

- Added a new `docker/Dockerfile` that defines a minimal Alpine-based image, copies the built server binary and configuration, and sets the appropriate entrypoint for running the application.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
