### PR TITLE
chore: docker pull troubleshoot ghcr.io credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ A Docker image is available as well. You can pull it from GitHub Container Regis
 docker pull ghcr.io/leoborai/mate:latest
 ```
 
+#### Troubleshooting
+
+##### Error response from daemon "denied"
+
+If you are getting:
+
+```bash
+docker pull ghcr.io/leoborai/mate:latest
+Error response from daemon: Head "https://ghcr.io/v2/leoborai/mate/manifests/latest": denied: denied
+```
+
+This is likely to be related to GHCR Credentials in your environment.
+You can fix this by logging out usinc the following command:
+
+```bash
+docker logout ghcr.io
+```
+
 ### GitHub Releases
 
 You can also download precompiled binaries from the [GitHub Releases](https://githeub.com/LeoBorai/mate/releases) page.


### PR DESCRIPTION
Added troubleshooting section for Docker pull errors.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
