### PR TITLE
chore(server): use port `6283`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ A Docker image is available as well. You can pull it from GitHub Container Regis
 docker pull ghcr.io/leoborai/mate:latest
 ```
 
+```bash
+docker run -p 6283:6283 ghcr.io/leoborai/mate
+```
+
+Then use `mate` CLI as regularly. `mate` CLI will perform requests to the `mate`
+server running inside the Docker container.
+
 #### Troubleshooting
 
 ##### Error response from daemon "denied"

--- a/bin/dev/create.sh
+++ b/bin/dev/create.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-API_URL="http://localhost:8080"
+API_URL="http://localhost:6283"
 
 echo "=== Creating Jobs ==="
 

--- a/bin/dev/list.sh
+++ b/bin/dev/list.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-API_URL="http://localhost:8080"
+API_URL="http://localhost:6283"
 
 echo -e "\n=== Listing All Jobs ==="
 curl -s $API_URL/api/v0/jobs | jq '.[] | {id, name, status, result}'

--- a/docs/config/local.toml
+++ b/docs/config/local.toml
@@ -3,7 +3,7 @@ type = "UnixSocket"
 base_path = "/tmp/mate_sys"
 
 [hub]
-api_addr = "127.0.0.1:8080"
+api_addr = "127.0.0.1:6283"
 
 [storage]
 backend = "Memory"

--- a/src/cli/src/cli/cmd/job/list.rs
+++ b/src/cli/src/cli/cmd/job/list.rs
@@ -33,7 +33,7 @@ pub struct JobListOpt {
 
 impl JobListOpt {
     pub async fn exec(&self) -> Result<()> {
-        let client = Client::new("http://localhost:8080".to_string());
+        let client = Client::new("http://localhost:6283".to_string());
 
         match client.retrieve_jobs().await {
             Ok(jobs) => {

--- a/src/cli/src/cli/cmd/job/new.rs
+++ b/src/cli/src/cli/cmd/job/new.rs
@@ -21,7 +21,7 @@ pub struct JobNewOpt {
 
 impl JobNewOpt {
     pub async fn exec(&self) -> Result<()> {
-        let client = Client::new("http://localhost:8080".to_string());
+        let client = Client::new("http://localhost:6283".to_string());
 
         match client
             .create_job(self.name.clone(), self.task.clone(), self.payload.clone())

--- a/src/cli/src/cli/cmd/job/view.rs
+++ b/src/cli/src/cli/cmd/job/view.rs
@@ -12,7 +12,7 @@ pub struct JobViewOpt {
 
 impl JobViewOpt {
     pub async fn exec(&self) -> Result<()> {
-        let client = Client::new("http://localhost:8080".to_string());
+        let client = Client::new("http://localhost:6283".to_string());
 
         match client.find_job_by_id(self.id).await {
             Ok(Some(job)) => {

--- a/src/cli/src/server.rs
+++ b/src/cli/src/server.rs
@@ -18,7 +18,7 @@ use crate::utils::shutdown_signal;
 pub async fn run_server(config: &Config, hub: Arc<Hub>) -> Result<()> {
     let services = Arc::new(Services::new(hub));
     let app = Router::new().merge(routes(services));
-    let listener = TcpListener::bind("0.0.0.0:8080").await?;
+    let listener = TcpListener::bind("0.0.0.0:6283").await?;
 
     info!(addr=?config.hub.api_addr, "Server listening");
 

--- a/src/config/src/lib.rs
+++ b/src/config/src/lib.rs
@@ -50,7 +50,7 @@ mod test {
             base_path = "/tmp/mate_sys"
 
             [hub]
-            api_addr = "127.0.0.1:8080"
+            api_addr = "127.0.0.1:6283"
 
             [storage]
             backend = "Memory"

--- a/test/smoke.sh
+++ b/test/smoke.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-API_URL="http://localhost:8080"
+API_URL="http://localhost:6283"
 
 echo "=== Creating Jobs ==="
 


### PR DESCRIPTION
Use the port `6283` for Mate HTTP Server. The hardcoded parts of the CLI and Client
are also using this port. This is while on development, later this should be made
configurable.