### PR TITLE
feat: use http client for task list/load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -1738,6 +1739,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1757,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -2152,6 +2180,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http 1.4.0",
  "http-body",
@@ -2162,6 +2191,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2565,6 +2595,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -3017,6 +3053,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, features = ["multipart"] }
 bytes = { workspace = true }
 chrono = { workspace = true }
 humantime = { workspace = true }

--- a/src/cli/src/cli/cmd/hub/start.rs
+++ b/src/cli/src/cli/cmd/hub/start.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use clap::Parser;
+use mate_repository::TaskRepository;
 use tracing::error;
 
 use crate::process::hub::Hub;
@@ -22,11 +23,12 @@ impl HubStartOpt {
         let mut hub = Hub::new(self.config.clone()).await?;
         let child_processes = hub.spawn_processes().await?;
         let hub = Arc::new(hub);
+        let repo = Arc::new(TaskRepository::local().await?);
 
         hub.wait_for_components().await?;
 
         tokio::select! {
-            Err(err) = run_server(hub.config(), Arc::clone(&hub)) => {
+            Err(err) = run_server(hub.config(), Arc::clone(&hub), Arc::clone(&repo)) => {
                 error!("Server returned an error. {:#?}", err);
             },
             _ = shutdown_signal() => {

--- a/src/cli/src/cli/cmd/task/list.rs
+++ b/src/cli/src/cli/cmd/task/list.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use tabled::Tabled;
 
-use mate_repository::TaskRepository;
+use mate::client::Client;
 
 use crate::cli::utils::display::print_table;
 
@@ -18,18 +18,26 @@ pub struct TaskListOpt {}
 
 impl TaskListOpt {
     pub async fn exec(&self) -> Result<()> {
-        let repo = TaskRepository::local().await?;
-        let tasks = repo.list().await?;
-        let tasks: Vec<TaskListItem> = tasks
-            .into_iter()
-            .map(|task| TaskListItem {
-                namespace: task.namespace,
-                name: task.name,
-                version: task.version.to_string(),
-            })
-            .collect();
+        let client = Client::new("http://localhost:6283");
 
-        print_table(tasks);
+        match client.api.v0.tasks.retrieve().await {
+            Ok(tasks) => {
+                let data: Vec<TaskListItem> = tasks
+                    .into_iter()
+                    .map(|task| TaskListItem {
+                        namespace: task.namespace,
+                        name: task.name,
+                        version: task.version.to_string(),
+                    })
+                    .collect();
+
+                print_table(data);
+            }
+            Err(e) => {
+                println!("Failed to list tasks: {}", e);
+            }
+        }
+
         Ok(())
     }
 }

--- a/src/cli/src/cli/cmd/task/load.rs
+++ b/src/cli/src/cli/cmd/task/load.rs
@@ -4,8 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 use tokio::fs::read;
 
-use mate::proto::task::TaskIdentifier;
-use mate_repository::TaskRepository;
+use mate::{client::Client, proto::task::TaskIdentifier};
 
 #[derive(Debug, Parser)]
 pub struct TaskLoadOpt {
@@ -17,14 +16,20 @@ pub struct TaskLoadOpt {
 
 impl TaskLoadOpt {
     pub async fn exec(&self) -> Result<()> {
-        let repo = TaskRepository::local().await?;
         let wasm = read(&self.path).await?;
+        let client = Client::new("http://localhost:6283");
 
-        repo.store(&self.id, wasm.into()).await?;
-        println!(
-            "Task \"{}\" has been loaded into local the repository.",
-            self.id
-        );
+        match client.api.v0.tasks.create(&self.id, wasm).await {
+            Ok(()) => {
+                println!(
+                    "Task \"{}\" has been loaded into local the repository.",
+                    self.id
+                );
+            }
+            Err(e) => {
+                eprintln!("Failed to load task: {}", e);
+            }
+        }
 
         Ok(())
     }

--- a/src/cli/src/server.rs
+++ b/src/cli/src/server.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use axum::Router;
+use mate_repository::TaskRepository;
 use tokio::net::TcpListener;
 use tracing::info;
 
@@ -15,8 +16,8 @@ use crate::server::api::routes;
 use crate::server::state::Services;
 use crate::utils::shutdown_signal;
 
-pub async fn run_server(config: &Config, hub: Arc<Hub>) -> Result<()> {
-    let services = Arc::new(Services::new(hub));
+pub async fn run_server(config: &Config, hub: Arc<Hub>, repo: Arc<TaskRepository>) -> Result<()> {
+    let services = Arc::new(Services::new(hub, repo));
     let app = Router::new().merge(routes(services));
     let listener = TcpListener::bind("0.0.0.0:6283").await?;
 

--- a/src/cli/src/server/api/v0.rs
+++ b/src/cli/src/server/api/v0.rs
@@ -1,4 +1,5 @@
 pub mod jobs;
+pub mod tasks;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -6,7 +7,9 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 pub fn routes() -> Router {
-    Router::new().nest("/jobs", jobs::routes())
+    Router::new()
+        .nest("/jobs", jobs::routes())
+        .nest("/tasks", tasks::routes())
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/cli/src/server/api/v0/tasks.rs
+++ b/src/cli/src/server/api/v0/tasks.rs
@@ -1,0 +1,10 @@
+mod create;
+mod retrieve;
+
+use axum::routing::{Router, get, post};
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/{namespace}/{name}/{version}", post(create::handler))
+        .route("/", get(retrieve::handler))
+}

--- a/src/cli/src/server/api/v0/tasks/create.rs
+++ b/src/cli/src/server/api/v0/tasks/create.rs
@@ -1,0 +1,59 @@
+use std::str::FromStr;
+
+use axum::Extension;
+use axum::extract::{Multipart, Path};
+use axum::http::StatusCode;
+use bytes::Bytes;
+
+use mate::proto::task::TaskIdentifier;
+
+use crate::server::api::v0::ApiError;
+use crate::server::state::SharedServices;
+
+pub async fn handler(
+    Extension(services): Extension<SharedServices>,
+    Path((namespace, name, version)): Path<(String, String, String)>,
+    mut multipart: Multipart,
+) -> Result<(), ApiError> {
+    let id = TaskIdentifier::from_str(&format!("{}/{}@{}", namespace, name, version)).map_err(
+        |err| ApiError {
+            message: err.to_string(),
+            status: StatusCode::BAD_GATEWAY,
+        },
+    )?;
+    let wasm = extract_file_from_multipart(&mut multipart, "task").await?;
+
+    services
+        .repo
+        .store(&id, wasm)
+        .await
+        .map_err(|err| ApiError {
+            message: err.to_string(),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        })?;
+
+    Ok(())
+}
+
+async fn extract_file_from_multipart(
+    multipart: &mut Multipart,
+    field_name: &str,
+) -> Result<Bytes, ApiError> {
+    while let Some(field) = multipart.next_field().await.map_err(|e| ApiError {
+        message: e.to_string(),
+        status: StatusCode::BAD_REQUEST,
+    })? {
+        if field.name() == Some(field_name) {
+            let data = field.bytes().await.map_err(|e| ApiError {
+                message: e.to_string(),
+                status: StatusCode::BAD_REQUEST,
+            })?;
+            return Ok(data);
+        }
+    }
+
+    Err(ApiError {
+        message: format!("Field '{}' not found in multipart data", field_name),
+        status: StatusCode::BAD_REQUEST,
+    })
+}

--- a/src/cli/src/server/api/v0/tasks/retrieve.rs
+++ b/src/cli/src/server/api/v0/tasks/retrieve.rs
@@ -1,0 +1,18 @@
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+
+use mate::proto::task::TaskIdentifier;
+
+use crate::server::api::v0::ApiError;
+use crate::server::state::SharedServices;
+
+pub async fn handler(
+    Extension(services): Extension<SharedServices>,
+) -> Result<Json<Vec<TaskIdentifier>>, ApiError> {
+    let tasks = services.repo.list().await.map_err(|err| ApiError {
+        message: err.to_string(),
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+    })?;
+
+    Ok(Json(tasks))
+}

--- a/src/cli/src/server/state.rs
+++ b/src/cli/src/server/state.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use mate_repository::TaskRepository;
+
 use crate::process::hub::Hub;
 
 pub type SharedServices = Arc<Services>;
@@ -7,10 +9,11 @@ pub type SharedServices = Arc<Services>;
 #[derive(Clone)]
 pub struct Services {
     pub hub: Arc<Hub>,
+    pub repo: Arc<TaskRepository>,
 }
 
 impl Services {
-    pub fn new(hub: Arc<Hub>) -> Self {
-        Self { hub }
+    pub fn new(hub: Arc<Hub>, repo: Arc<TaskRepository>) -> Self {
+        Self { hub, repo }
     }
 }

--- a/src/mate/Cargo.toml
+++ b/src/mate/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "multipart"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 semver = { workspace = true }

--- a/src/mate/src/client/api/v0.rs
+++ b/src/mate/src/client/api/v0.rs
@@ -1,19 +1,23 @@
 pub mod jobs;
+pub mod tasks;
 
 use std::sync::Arc;
 
 use crate::client::HttpClient;
 use crate::client::api::v0::jobs::ApiV0Jobs;
+use crate::client::api::v0::tasks::ApiV0Tasks;
 
 #[derive(Clone)]
 pub struct V0 {
     pub jobs: ApiV0Jobs,
+    pub tasks: ApiV0Tasks,
 }
 
 impl V0 {
     pub(super) fn new(http_client: Arc<HttpClient>) -> Self {
         Self {
             jobs: ApiV0Jobs::new(Arc::clone(&http_client)),
+            tasks: ApiV0Tasks::new(Arc::clone(&http_client)),
         }
     }
 }

--- a/src/mate/src/client/api/v0/tasks.rs
+++ b/src/mate/src/client/api/v0/tasks.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+use reqwest::multipart::{Form, Part};
+use uuid::Uuid;
+
+use crate::client::HttpClient;
+use crate::proto::task::TaskIdentifier;
+
+pub struct RetrieveJobsQuery {
+    pub id: Option<Uuid>,
+}
+
+#[derive(Clone)]
+pub struct ApiV0Tasks {
+    http_client: Arc<HttpClient>,
+}
+
+impl ApiV0Tasks {
+    pub(super) fn new(http_client: Arc<HttpClient>) -> Self {
+        Self { http_client }
+    }
+
+    pub async fn create(&self, id: &TaskIdentifier, bytes: Vec<u8>) -> Result<()> {
+        let form = Form::new().part(
+            "task",
+            Part::bytes(bytes)
+                .file_name("task.wasm")
+                .mime_str("application/octet-stream")?,
+        );
+        let response = self
+            .http_client
+            .client
+            .post(format!(
+                "{}/api/v0/tasks/{}/{}/{}",
+                self.http_client.base_url, id.namespace, id.name, id.version
+            ))
+            .multipart(form)
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let error_text = response.text().await?;
+
+        bail!("Request failed with status {}: {}", status, error_text)
+    }
+
+    pub async fn retrieve(&self) -> Result<Vec<TaskIdentifier>> {
+        let request = self
+            .http_client
+            .client
+            .get(format!("{}/api/v0/tasks", self.http_client.base_url));
+        let response = request.send().await?;
+
+        if response.status().is_success() {
+            let tasks = response.json::<Vec<TaskIdentifier>>().await?;
+            return Ok(tasks);
+        }
+        let status = response.status();
+        let error_text = response.text().await?;
+
+        bail!("Request failed with status {}: {}", status, error_text)
+    }
+}

--- a/src/repository/src/lib.rs
+++ b/src/repository/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod backend;
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use bytes::Bytes;
 
@@ -7,18 +9,19 @@ use mate::proto::task::TaskIdentifier;
 
 use crate::backend::{Backend, LocalBackend};
 
+#[derive(Clone)]
 pub struct TaskRepository {
-    backend: Box<dyn Backend>,
+    backend: Arc<dyn Backend + Send + Sync>,
 }
 
 impl TaskRepository {
-    pub fn new(backend: Box<dyn Backend>) -> Self {
+    pub fn new(backend: Arc<dyn Backend + Send + Sync>) -> Self {
         Self { backend }
     }
 
     pub async fn local() -> Result<Self> {
         let local = LocalBackend::new().await?;
-        let backend = Box::new(local);
+        let backend = Arc::new(local);
         Ok(Self { backend })
     }
 


### PR DESCRIPTION
Use the HTTP Server to perform `TaskRepository` access from the CLI. This way the repository is always local to the mate instance and is also accessible via HTTP Server.