### PR TITLE
feat: provide support for `max_attempts`

### DIFF
--- a/src/cli/src/cli/cmd/job/list.rs
+++ b/src/cli/src/cli/cmd/job/list.rs
@@ -17,7 +17,7 @@ struct JobListItem {
     status: String,
     task: String,
     result: String,
-    retries: String,
+    attempts: String,
     tte: String,
 }
 
@@ -77,7 +77,7 @@ impl JobListOpt {
                                 Some(res) => format!("{}", res),
                                 None => "N/A".to_string(),
                             },
-                            retries: format!("{}/{}", job.retry_count, job.max_retries),
+                            attempts: format!("{}/{}", job.attempts, job.max_attempts),
                             tte: tte_label,
                         }
                     })

--- a/src/cli/src/cli/cmd/job/new.rs
+++ b/src/cli/src/cli/cmd/job/new.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use serde_json::Value;
 
 use mate::client::Client;
+use mate::client::api::v0::jobs::CreateJobRequest;
 use mate::proto::task::TaskIdentifier;
 
 use crate::cli::utils::io::parse_json;
@@ -12,12 +13,15 @@ pub struct JobNewOpt {
     /// Name of the job
     #[clap(long, short)]
     pub name: String,
-    /// Payload for the job in JSON format
+    /// Arguments for the job in JSON format
     #[clap(long, short, value_parser = parse_json)]
-    pub payload: Value,
+    pub args: Value,
     /// Task to execute this job with
     #[clap(long, short)]
     pub task: TaskIdentifier,
+    /// Maximum number of attempts for the job
+    #[clap(long, short, default_value_t = 3)]
+    pub max_attempts: u32,
 }
 
 impl JobNewOpt {
@@ -28,7 +32,12 @@ impl JobNewOpt {
             .api
             .v0
             .jobs
-            .create(self.name.clone(), self.task.clone(), self.payload.clone())
+            .create(CreateJobRequest {
+                name: self.name.clone(),
+                task: self.task.clone(),
+                args: self.args.clone(),
+                max_attempts: Some(self.max_attempts),
+            })
             .await
         {
             Ok(job) => {

--- a/src/cli/src/process/executor.rs
+++ b/src/cli/src/process/executor.rs
@@ -86,7 +86,7 @@ impl ExecutorProcess {
         let tid = job.task.clone();
         let exid = self.id;
         let job_id = job.id;
-        let payload = job.payload.clone();
+        let args = job.args.clone();
         let process_type = self.process_type();
         let task = match self.get_or_load_module(&tid).await {
             Ok(m) => m,
@@ -111,12 +111,12 @@ impl ExecutorProcess {
             }
         };
 
-        let payload_bytes: Bytes = serde_json::to_vec(&payload)?.into();
+        let args_bytes: Bytes = serde_json::to_vec(&args)?.into();
 
         tokio::spawn(async move {
             info!(%job_id, %tid, %exid, "Executing Job");
 
-            let result = executor.run(task, payload_bytes).await;
+            let result = executor.run(task, args_bytes).await;
             let job_result = match result {
                 Ok(output) => {
                     info!(%job_id, "Job completed successfully");

--- a/src/cli/src/server/api/v0/jobs/create.rs
+++ b/src/cli/src/server/api/v0/jobs/create.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
 use axum::http::StatusCode;
@@ -17,19 +16,15 @@ use crate::server::state::SharedServices;
 #[derive(Debug, Deserialize)]
 pub struct CreateJobRequest {
     name: String,
-    task: String,
-    payload: Value,
+    task: TaskIdentifier,
+    args: Value,
+    max_attempts: Option<u32>,
 }
 
 pub async fn handler(
     Extension(services): Extension<SharedServices>,
     Json(job_data): Json<CreateJobRequest>,
 ) -> Result<Json<Job>, ApiError> {
-    let task = TaskIdentifier::from_str(&job_data.task).map_err(|_| ApiError {
-        message: String::from("Invalid task identifier format"),
-        status: StatusCode::BAD_REQUEST,
-    })?;
-
     if job_data.name.is_empty() || job_data.name.contains(' ') {
         return Err(ApiError {
             message: String::from("Job name cannot contain spaces and cannot be empty"),
@@ -37,25 +32,18 @@ pub async fn handler(
         });
     }
 
-    if job_data.task.is_empty() || job_data.task.contains(' ') {
-        return Err(ApiError {
-            message: String::from("Job task cannot contain spaces and cannot be empty"),
-            status: StatusCode::BAD_REQUEST,
-        });
-    }
-
     let job = Job {
         id: Uuid::new_v4(),
         name: job_data.name,
-        payload: job_data.payload,
+        args: job_data.args,
         status: JobStatus::Scheduled,
         scheduled_at: SystemTime::now() + Duration::from_secs(5),
         started_at: None,
         completed_at: None,
         result: None,
-        retry_count: 0,
-        max_retries: 3,
-        task,
+        attempts: 0,
+        max_attempts: job_data.max_attempts.unwrap_or(3),
+        task: job_data.task,
         errors: Vec::new(),
     };
     let msg = Message::new(

--- a/src/mate/src/client/api/v0/jobs.rs
+++ b/src/mate/src/client/api/v0/jobs.rs
@@ -5,16 +5,15 @@ use serde::Serialize;
 use serde_json::Value;
 use uuid::Uuid;
 
-use crate::{
-    client::HttpClient,
-    proto::{job::Job, task::TaskIdentifier},
-};
+use crate::client::HttpClient;
+use crate::proto::{job::Job, task::TaskIdentifier};
 
 #[derive(Debug, Serialize)]
-struct CreateJobRequest {
-    name: String,
-    task: String,
-    payload: Value,
+pub struct CreateJobRequest {
+    pub name: String,
+    pub task: TaskIdentifier,
+    pub args: Value,
+    pub max_attempts: Option<u32>,
 }
 
 pub struct RetrieveJobsQuery {
@@ -31,18 +30,12 @@ impl ApiV0Jobs {
         Self { http_client }
     }
 
-    pub async fn create(&self, name: String, task: TaskIdentifier, payload: Value) -> Result<Job> {
-        let task = task.to_string();
-        let request = CreateJobRequest {
-            name,
-            task,
-            payload,
-        };
+    pub async fn create(&self, payload: CreateJobRequest) -> Result<Job> {
         let response = self
             .http_client
             .client
             .post(format!("{}/api/v0/jobs", self.http_client.base_url)) // Adjust the path as needed
-            .json(&request)
+            .json(&payload)
             .send()
             .await?;
 

--- a/src/mate/src/proto/job.rs
+++ b/src/mate/src/proto/job.rs
@@ -15,7 +15,7 @@ pub type ExecutorId = usize;
 pub struct Job {
     pub id: Uuid,
     pub name: String,
-    pub payload: Value,
+    pub args: Value,
     pub status: JobStatus,
     pub scheduled_at: SystemTime,
     pub task: TaskIdentifier,
@@ -23,8 +23,8 @@ pub struct Job {
     pub completed_at: Option<SystemTime>,
     pub errors: Vec<String>,
     pub result: Option<JobResult>,
-    pub retry_count: u32,
-    pub max_retries: u32,
+    pub attempts: u32,
+    pub max_attempts: u32,
 }
 
 impl PartialOrd for Job {

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -72,6 +72,7 @@ impl Storage {
                 let mut jobs = self.jobs.lock().await;
 
                 if let Some(job) = jobs.get_mut(&id) {
+                    job.attempts += 1;
                     job.completed_at = Some(SystemTime::now());
 
                     match &result {
@@ -79,9 +80,8 @@ impl Storage {
                             job.status = JobStatus::Completed;
                         }
                         JobResult::Failure(err) => {
-                            if job.retry_count < job.max_retries {
+                            if job.attempts < job.max_attempts {
                                 job.status = JobStatus::Scheduled;
-                                job.retry_count += 1;
                                 job.errors.push(err.to_string());
                             } else {
                                 job.status = JobStatus::Failed;


### PR DESCRIPTION
This pull request refactors the job creation and execution logic to improve clarity and flexibility around job arguments and retry behavior. The main changes include renaming fields related to job arguments and attempts, updating struct definitions and method signatures, and ensuring consistent usage across the CLI, API, and storage layers.

**Job Arguments and Attempts Refactor:**

* Renamed the `payload` field to `args` and the `retries` fields to `attempts`/`max_attempts` in the `Job` struct and related code, improving clarity around job input and retry semantics. [[1]](diffhunk://#diff-5a73b36b7a93d248d73c20fa02d67ad64b40bf765721b8523c6575d4ab61b1e4L18-R27) [[2]](diffhunk://#diff-0223f29c396daabb4a9346c573531e6075dc6f07609b301eea9729d71d19b29bL20-R20)
* Updated all relevant code to use the new `args`, `attempts`, and `max_attempts` fields, including job creation, execution, and display logic. [[1]](diffhunk://#diff-0c098a223396c7fad03c362d707f7840d5b31c1a04b1fa59f832e3b629591e80L89-R89) [[2]](diffhunk://#diff-0c098a223396c7fad03c362d707f7840d5b31c1a04b1fa59f832e3b629591e80L114-R119) [[3]](diffhunk://#diff-0223f29c396daabb4a9346c573531e6075dc6f07609b301eea9729d71d19b29bL80-R80) [[4]](diffhunk://#diff-835e7a61ce087f455b23aca6fdf462bef188983184b7c604086e6ae94ee38174R75-L84)

**Job Creation and API Changes:**

* Modified the job creation API to accept a `CreateJobRequest` struct with `args` and `max_attempts` fields, and updated validation logic accordingly. [[1]](diffhunk://#diff-a67903457ce9ea51509609809ddc33d1cafca2e1b8b8c6a2bddd6c25932f10d8L20-R46) [[2]](diffhunk://#diff-a67903457ce9ea51509609809ddc33d1cafca2e1b8b8c6a2bddd6c25932f10d8L20-R46)
* Added a `max_attempts` option to the CLI job creation command (`JobNewOpt`), allowing users to specify the maximum number of attempts for a job. [[1]](diffhunk://#diff-3db78127a17e9c52fc4e6bd34871c89724cc84adda6368a52dfae01bbf352e7cL15-R24) [[2]](diffhunk://#diff-3db78127a17e9c52fc4e6bd34871c89724cc84adda6368a52dfae01bbf352e7cL31-R40)

**Client and Internal API Updates:**

* Made the `CreateJobRequest` struct public and updated its fields to match the new argument and attempt conventions, ensuring type consistency across the client and server.
* Updated the job creation method in the client API to accept the new `CreateJobRequest` struct directly.

These changes collectively enhance the clarity of job-related data structures and make the retry mechanism more flexible and explicit.