### PR TITLE
fix: jobs must run once unless errored

### DIFF
--- a/src/cli/src/process/executor.rs
+++ b/src/cli/src/process/executor.rs
@@ -173,10 +173,13 @@ impl ExecutorProcess {
 
     async fn handle_message(&self, msg: Message) -> Option<MessagePayload> {
         match msg.payload {
-            MessagePayload::ExecuteJob(job) => match self.execute(job.clone()).await {
-                Ok(()) => Some(MessagePayload::JobAccepted(job.id)),
-                Err(err) => Some(MessagePayload::JobFailed(job.id, err.to_string())),
-            },
+            MessagePayload::ExecuteJob(job) => {
+                info!("Received ExecuteJob message for job {}", job.id);
+                match self.execute(job.clone()).await {
+                    Ok(()) => Some(MessagePayload::JobAccepted(job.id)),
+                    Err(err) => Some(MessagePayload::JobFailed(job.id, err.to_string())),
+                }
+            }
             MessagePayload::Ping => Some(MessagePayload::Pong),
             MessagePayload::Shutdown => Some(MessagePayload::ShutdownAck),
             _ => None,

--- a/src/ipc/src/protocol.rs
+++ b/src/ipc/src/protocol.rs
@@ -56,7 +56,7 @@ pub struct Message {
     pub from: ProcessType,
     pub to: ProcessType,
     pub payload: MessagePayload,
-    pub reply_to: Option<Uuid>, // For request-response pattern
+    pub reply_to: Option<Uuid>,
 }
 
 impl Message {

--- a/src/scheduler/src/lib.rs
+++ b/src/scheduler/src/lib.rs
@@ -4,7 +4,6 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::{Result, bail};
 use tokio::sync::Mutex;
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::time::{interval, sleep};
 use tracing::{error, info, warn};
 
@@ -24,14 +23,11 @@ pub struct Scheduler {
     executor_count: usize,
     current_executor: Mutex<usize>,
     queue: Arc<Mutex<BinaryHeap<Job>>>,
-    rx: Arc<Mutex<UnboundedReceiver<Job>>>,
-    tx: UnboundedSender<Job>,
 }
 
 impl Scheduler {
     pub async fn new(transport: Box<dyn Transport>, executor_count: usize) -> Result<Self> {
         let ipc = Arc::new(IpcServer::new(IPC_SENDER_SCHEDULER, transport));
-        let (tx, rx) = unbounded_channel();
         let queue = Arc::new(Mutex::new(BinaryHeap::new()));
 
         Ok(Self {
@@ -39,8 +35,6 @@ impl Scheduler {
             executor_count,
             current_executor: Mutex::new(0),
             queue,
-            rx: Arc::new(Mutex::new(rx)),
-            tx,
         })
     }
 
@@ -66,6 +60,7 @@ impl Scheduler {
 
         loop {
             let mut queue = self.queue.lock().await;
+            info!(?queue, "Jobs in queue");
             let job = match queue.peek() {
                 Some(job) => job.clone(),
                 None => {
@@ -81,6 +76,7 @@ impl Scheduler {
                 Ok(duration) => duration,
                 Err(_) => {
                     if let Some(job) = queue.pop() {
+                        info!(?queue, "Jobs left in queue");
                         drop(queue);
                         info!("Executing overdue job: {:?}", job.id);
                         if let Err(err) = self.dispatch_job(job).await {
@@ -98,18 +94,7 @@ impl Scheduler {
             let sleep_duration = sleep_duration.max(SLEEP_INTERVAL);
 
             info!("Sleeping for {:?} until next job", sleep_duration);
-
-            tokio::select! {
-                _ = sleep(sleep_duration) => {}
-                Some(new_job) = async {
-                    let mut rx = self.rx.lock().await;
-                    rx.recv().await
-                } => {
-                    info!("New job received, adding to queue");
-                    let mut queue = self.queue.lock().await;
-                    queue.push(new_job);
-                }
-            }
+            sleep(sleep_duration).await;
         }
     }
 
@@ -229,15 +214,6 @@ impl Scheduler {
         match msg.payload {
             MessagePayload::Ping => Some(MessagePayload::Pong),
             MessagePayload::Shutdown => Some(MessagePayload::ShutdownAck),
-            MessagePayload::JobStored(Ok(job)) => {
-                let id = job.id;
-
-                if let Err(err) = self.tx.send(job) {
-                    error!(?err, "Failed to enqueue new job received from Storage");
-                }
-
-                Some(MessagePayload::JobAccepted(id))
-            }
             _ => None,
         }
     }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 
 use anyhow::{Result, bail};
 use tokio::sync::Mutex;
-use tracing::{debug, error, info};
+use tracing::{debug, info};
 use uuid::Uuid;
 
 use mate::proto::job::{Job, JobResult, JobStatus};
@@ -13,6 +13,7 @@ use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
 
 const IPC_SENDER_STORAGE: ProcessType = ProcessType::Storage;
+const MAX_JOBS_PER_BATCH: usize = 5;
 
 pub struct Storage {
     ipc: Arc<IpcServer>,
@@ -103,19 +104,6 @@ impl Storage {
                 let mut jobs = self.jobs.lock().await;
                 jobs.insert(id, job.clone());
                 drop(jobs);
-
-                if let Err(err) = self
-                    .ipc
-                    .send(Message::new(
-                        ProcessType::Storage,
-                        ProcessType::Scheduler,
-                        MessagePayload::JobStored(Ok(job.clone())),
-                    ))
-                    .await
-                {
-                    error!(?err, "Failed to notify Scheduler about stored Job {id}");
-                }
-
                 Some(MessagePayload::JobStored(Ok(job)))
             }
             MessagePayload::QueryJobs(query) => {
@@ -136,18 +124,19 @@ impl Storage {
                 info!(jobs = jobs.len(), "Returning jobs from storage");
                 Some(MessagePayload::JobsResult(jobs))
             }
-            MessagePayload::ClaimJobs((_start, _end)) => {
+            MessagePayload::ClaimJobs((_, end)) => {
                 let mut jobs = self.jobs.lock().await;
                 let jobs: Vec<Job> = jobs
                     .iter_mut()
                     .filter(|(_, j)| j.status == JobStatus::Scheduled)
-                    .take(5)
+                    .filter(|(_, j)| j.scheduled_at <= end)
+                    .take(MAX_JOBS_PER_BATCH)
                     .map(|(_, job)| {
                         job.status = JobStatus::Claimed;
                         job.clone()
                     })
                     .collect();
-
+                info!(jobs = jobs.len(), "Claimed jobs from storage");
                 Some(MessagePayload::JobsResult(jobs))
             }
             MessagePayload::Ping => Some(MessagePayload::Pong),


### PR DESCRIPTION
As of today new jobs are being sent directly to the Executor in parallel as sent to Scheduler this was as part of an effort to proactively interrupt the job if it happen to run before the current sleep window of the executor. The issue is that queues are then populated with data not controlled by the Scheduler causing jobs to run twice.