### PR TITLE
fix: build doesnt use config.toml

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -27,7 +27,6 @@ docker-build:
 # Builds the Docker image
 docker-build-image: docker-build
     mkdir -p ./docker/tmp/
-    cp ./docs/config/local.toml ./docker/tmp/local.toml
     cp ./target/{{target_release}}/release/mate ./docker/tmp/mate
     chmod +x ./docker/tmp/mate
     docker build -t "mate:$(cargo tag current)" ./docker


### PR DESCRIPTION
This pull request makes a minor update to the Docker build process by removing the step that copies the `local.toml` configuration file into the Docker build context. This simplifies the build process and avoids including unnecessary configuration files in the Docker image.