### PR TITLE
feat(server): introduce `health` endpoint

### DIFF
--- a/src/cli/src/cli/cmd/run.rs
+++ b/src/cli/src/cli/cmd/run.rs
@@ -7,7 +7,9 @@ use mate_config::Config;
 use mate_repository::TaskRepository;
 use tracing::error;
 
-use crate::{process::hub::Hub, server::run_server, utils::shutdown_signal};
+use crate::process::hub::Hub;
+use crate::server::run_server;
+use crate::utils::shutdown_signal;
 
 #[derive(Debug, Parser)]
 pub enum RunCmd {}
@@ -19,9 +21,10 @@ impl RunCmd {
         let child_processes = hub.spawn_processes().await?;
         let hub = Arc::new(hub);
         let repo = Arc::new(TaskRepository::local().await?);
+        let config = Arc::new(hub.config().to_owned());
 
         tokio::select! {
-            Err(err) = run_server(hub.config(), Arc::clone(&hub), Arc::clone(&repo)) => {
+            Err(err) = run_server(Arc::clone(&config), Arc::clone(&hub), Arc::clone(&repo)) => {
                 error!("Server returned an error. {:#?}", err);
             },
             _ = shutdown_signal() => {

--- a/src/cli/src/process/hub.rs
+++ b/src/cli/src/process/hub.rs
@@ -15,7 +15,7 @@ use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 
 use crate::transport::make_transport;
 
-const IPC_SENDER_HUB: ProcessType = ProcessType::Hub;
+pub const IPC_SENDER_HUB: ProcessType = ProcessType::Hub;
 
 pub struct Hub {
     config: Config,

--- a/src/cli/src/server.rs
+++ b/src/cli/src/server.rs
@@ -15,8 +15,12 @@ use crate::server::api::routes;
 use crate::server::state::Services;
 use crate::utils::shutdown_signal;
 
-pub async fn run_server(config: &Config, hub: Arc<Hub>, repo: Arc<TaskRepository>) -> Result<()> {
-    let services = Arc::new(Services::new(hub, repo));
+pub async fn run_server(
+    config: Arc<Config>,
+    hub: Arc<Hub>,
+    repo: Arc<TaskRepository>,
+) -> Result<()> {
+    let services = Arc::new(Services::new(Arc::clone(&config), hub, repo));
     let app = Router::new().merge(routes(services));
     let listener = TcpListener::bind("0.0.0.0:6283").await?;
 

--- a/src/cli/src/server/api/v0.rs
+++ b/src/cli/src/server/api/v0.rs
@@ -1,3 +1,4 @@
+pub mod health;
 pub mod jobs;
 pub mod tasks;
 
@@ -8,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 pub fn routes() -> Router {
     Router::new()
+        .nest("/health", health::routes())
         .nest("/jobs", jobs::routes())
         .nest("/tasks", tasks::routes())
 }

--- a/src/cli/src/server/api/v0/health.rs
+++ b/src/cli/src/server/api/v0/health.rs
@@ -1,9 +1,7 @@
-
 mod retrieve;
 
 use axum::routing::{Router, get};
 
 pub fn routes() -> Router {
-    Router::new()
-        .route("/", get(retrieve::handler))
+    Router::new().route("/", get(retrieve::handler))
 }

--- a/src/cli/src/server/api/v0/health.rs
+++ b/src/cli/src/server/api/v0/health.rs
@@ -1,0 +1,9 @@
+
+mod retrieve;
+
+use axum::routing::{Router, get};
+
+pub fn routes() -> Router {
+    Router::new()
+        .route("/", get(retrieve::handler))
+}

--- a/src/cli/src/server/api/v0/health/retrieve.rs
+++ b/src/cli/src/server/api/v0/health/retrieve.rs
@@ -1,0 +1,40 @@
+use axum::{Extension, Json};
+use serde::{Deserialize, Serialize};
+
+use mate::proto::job::{Job, JobQuery, JobStatus};
+use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
+
+use crate::process::hub::IPC_SENDER_HUB;
+use crate::server::api::v0::ApiError;
+use crate::server::state::SharedServices;
+
+#[derive(Serialize)]
+pub struct HealthResponse {
+    pub storage: bool,
+    pub schoduler: bool,
+}
+
+pub async fn handler(
+    Extension(services): Extension<SharedServices>,
+) -> Result<Json<HealthResponse>, ApiError> {
+    let storage = services.hub.ipc()
+        .request(Message::new(
+            IPC_SENDER_HUB,
+            ProcessType::Storage,
+            MessagePayload::Ping,
+        ))
+        .await;
+
+    let storage = services.hub.ipc()
+        .request(Message::new(
+            IPC_SENDER_HUB,
+            ProcessType::Scheduler,
+            MessagePayload::Ping,
+        ))
+        .await;
+
+    Ok(Json(HealthResponse {
+        storage: storage.is_ok(),
+        schoduler: storage.is_ok(),
+    }))
+}

--- a/src/cli/src/server/api/v0/health/retrieve.rs
+++ b/src/cli/src/server/api/v0/health/retrieve.rs
@@ -1,7 +1,6 @@
 use axum::{Extension, Json};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-use mate::proto::job::{Job, JobQuery, JobStatus};
 use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 
 use crate::process::hub::IPC_SENDER_HUB;
@@ -11,30 +10,30 @@ use crate::server::state::SharedServices;
 #[derive(Serialize)]
 pub struct HealthResponse {
     pub storage: bool,
-    pub schoduler: bool,
+    pub scheduler: bool,
 }
 
 pub async fn handler(
     Extension(services): Extension<SharedServices>,
 ) -> Result<Json<HealthResponse>, ApiError> {
-    let storage = services.hub.ipc()
+    let ipc = services.hub.ipc();
+    let storage = ipc
         .request(Message::new(
             IPC_SENDER_HUB,
             ProcessType::Storage,
             MessagePayload::Ping,
         ))
-        .await;
+        .await
+        .is_ok();
 
-    let storage = services.hub.ipc()
+    let scheduler = ipc
         .request(Message::new(
             IPC_SENDER_HUB,
             ProcessType::Scheduler,
             MessagePayload::Ping,
         ))
-        .await;
+        .await
+        .is_ok();
 
-    Ok(Json(HealthResponse {
-        storage: storage.is_ok(),
-        schoduler: storage.is_ok(),
-    }))
+    Ok(Json(HealthResponse { storage, scheduler }))
 }

--- a/src/cli/src/server/api/v0/health/retrieve.rs
+++ b/src/cli/src/server/api/v0/health/retrieve.rs
@@ -9,6 +9,7 @@ use crate::server::state::SharedServices;
 
 #[derive(Serialize)]
 pub struct HealthResponse {
+    pub executors: usize,
     pub storage: bool,
     pub scheduler: bool,
 }
@@ -16,6 +17,7 @@ pub struct HealthResponse {
 pub async fn handler(
     Extension(services): Extension<SharedServices>,
 ) -> Result<Json<HealthResponse>, ApiError> {
+    let executors = services.config.executors.count;
     let ipc = services.hub.ipc();
     let storage = ipc
         .request(Message::new(
@@ -35,5 +37,25 @@ pub async fn handler(
         .await
         .is_ok();
 
-    Ok(Json(HealthResponse { storage, scheduler }))
+    let mut active_executors = 0;
+
+    for i in 0..executors {
+        if ipc
+            .request(Message::new(
+                IPC_SENDER_HUB,
+                ProcessType::Executor(i),
+                MessagePayload::Ping,
+            ))
+            .await
+            .is_ok()
+        {
+            active_executors += 1;
+        }
+    }
+
+    Ok(Json(HealthResponse {
+        storage,
+        scheduler,
+        executors: active_executors,
+    }))
 }

--- a/src/cli/src/server/state.rs
+++ b/src/cli/src/server/state.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use mate_config::Config;
 use mate_repository::TaskRepository;
 
 use crate::process::hub::Hub;
@@ -8,12 +9,13 @@ pub type SharedServices = Arc<Services>;
 
 #[derive(Clone)]
 pub struct Services {
+    pub config: Arc<Config>,
     pub hub: Arc<Hub>,
     pub repo: Arc<TaskRepository>,
 }
 
 impl Services {
-    pub fn new(hub: Arc<Hub>, repo: Arc<TaskRepository>) -> Self {
-        Self { hub, repo }
+    pub fn new(config: Arc<Config>, hub: Arc<Hub>, repo: Arc<TaskRepository>) -> Self {
+        Self { hub, repo, config }
     }
 }


### PR DESCRIPTION
Introduces a `/health` endpoint to retrieve system status. For now returns only results from `ping` via IPC.