### PR TITLE
feat: support for `ClaimJob` and granular querying

### DIFF
--- a/src/cli/src/server/api/v0/jobs/retrieve.rs
+++ b/src/cli/src/server/api/v0/jobs/retrieve.rs
@@ -26,7 +26,9 @@ pub async fn handler(
         to: ProcessType::Storage,
         payload: MessagePayload::QueryJobs(JobQuery {
             status: query.status,
-            time_range: None,
+            max_time: None,
+            min_time: None,
+            limit: None,
         }),
         reply_to: None,
     };

--- a/src/ipc/src/protocol.rs
+++ b/src/ipc/src/protocol.rs
@@ -20,6 +20,11 @@ pub enum MessagePayload {
     JobUpdated(Result<(), String>),
 
     // Scheduler -> Storage
+    ClaimJob {
+        executor_id: ExecutorId,
+        job_id: Uuid,
+    },
+    #[warn(deprecated)]
     ClaimJobs((SystemTime, SystemTime)),
 
     // Scheduler -> Executor

--- a/src/mate/src/proto/job.rs
+++ b/src/mate/src/proto/job.rs
@@ -151,5 +151,7 @@ impl Display for JobResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobQuery {
     pub status: Option<JobStatus>,
-    pub time_range: Option<(SystemTime, SystemTime)>,
+    pub min_time: Option<SystemTime>,
+    pub max_time: Option<SystemTime>,
+    pub limit: Option<usize>,
 }

--- a/src/scheduler/src/lib.rs
+++ b/src/scheduler/src/lib.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 use tokio::time::{interval, sleep};
 use tracing::{debug, error, warn};
 
-use mate::proto::job::{Job, JobStatus};
+use mate::proto::job::{Job, JobQuery, JobStatus};
 use mate_ipc::channel::IpcServer;
 use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
@@ -17,6 +17,7 @@ const CHECK_INTERVAL: Duration = Duration::from_secs(10);
 const LOOKAHEAD_WINDOW: Duration = Duration::from_mins(5);
 const PERIODIC_RELOAD: Duration = Duration::from_secs(30);
 const SLEEP_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_JOBS_PER_BATCH: usize = 10;
 
 pub struct Scheduler {
     ipc: Arc<IpcServer>,
@@ -112,7 +113,12 @@ impl Scheduler {
         let request = Message::new(
             IPC_SENDER_SCHEDULER,
             ProcessType::Storage,
-            MessagePayload::ClaimJobs((now, future)),
+            MessagePayload::QueryJobs(JobQuery {
+                status: Some(JobStatus::Scheduled),
+                max_time: Some(future),
+                min_time: None,
+                limit: Some(MAX_JOBS_PER_BATCH),
+            }),
         );
 
         match self.ipc.request(request).await {
@@ -150,7 +156,10 @@ impl Scheduler {
             .send(Message::new(
                 IPC_SENDER_SCHEDULER,
                 ProcessType::Storage,
-                MessagePayload::UpdateJobStatus(job_id, JobStatus::Pending),
+                MessagePayload::ClaimJob {
+                    executor_id,
+                    job_id,
+                },
             ))
             .await?;
 

--- a/src/storage/src/backend.rs
+++ b/src/storage/src/backend.rs
@@ -19,4 +19,5 @@ pub trait Backend: Send + Sync {
         start: SystemTime,
         end: SystemTime,
     ) -> Result<Vec<Job>>;
+    async fn claim_job(&self, job_id: Uuid, executor_id: usize) -> Result<Job>;
 }

--- a/src/storage/src/backend/sqlite.rs
+++ b/src/storage/src/backend/sqlite.rs
@@ -139,8 +139,16 @@ impl super::Backend for SqliteBackend {
             sql.push_str(" AND status = ?");
         }
 
-        if query.time_range.is_some() {
-            sql.push_str(" AND scheduled_at >= ? AND scheduled_at <= ?");
+        if query.min_time.is_some() {
+            sql.push_str(" AND scheduled_at >= ?");
+        }
+
+        if query.max_time.is_some() {
+            sql.push_str(" AND scheduled_at <= ?");
+        }
+
+        if query.limit.is_some() {
+            sql.push_str(" ORDER BY scheduled_at LIMIT ?");
         }
 
         let mut q = sqlx::query_as::<_, JobRecord>(&sql);
@@ -148,10 +156,17 @@ impl super::Backend for SqliteBackend {
         if let Some(status) = query.status {
             q = q.bind(status.to_string());
         }
-        if let Some((start, end)) = query.time_range {
-            q = q
-                .bind(into_unix_timestamp(start)?)
-                .bind(into_unix_timestamp(end)?);
+
+        if let Some(min_time) = query.min_time {
+            q = q.bind(into_unix_timestamp(min_time)?);
+        }
+
+        if let Some(max_time) = query.max_time {
+            q = q.bind(into_unix_timestamp(max_time)?);
+        }
+
+        if let Some(limit) = query.limit {
+            q = q.bind(limit as i64);
         }
 
         let records = q.fetch_all(&self.pool).await?;
@@ -237,6 +252,25 @@ impl super::Backend for SqliteBackend {
         .await?;
 
         records.into_iter().map(|r| r.try_into()).collect()
+    }
+
+    async fn claim_job(&self, job_id: Uuid, _: usize) -> Result<Job> {
+        sqlx::query_as::<_, JobRecord>(
+            r#"
+            UPDATE jobs SET status = 'claimed'
+            WHERE
+                id = ?
+                AND status IN ('scheduled', 'failed')
+                AND attempts < max_attempts
+            ORDER BY scheduled_at
+            LIMIT 1
+            RETURNING *
+            "#,
+        )
+        .bind(job_id.to_string())
+        .fetch_one(&self.pool)
+        .await?
+        .try_into()
     }
 }
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -9,6 +9,7 @@ use anyhow::{Result, bail};
 use mate_ipc::channel::IpcServer;
 use mate_ipc::protocol::{Message, MessagePayload, ProcessType};
 use mate_ipc::transport::Transport;
+use tracing::error;
 
 use crate::backend::Backend;
 use crate::backend::sqlite::SqliteBackend;
@@ -86,6 +87,16 @@ impl Storage {
             MessagePayload::QueryJobs(query) => match self.backend.retrieve_jobs(query).await {
                 Ok(jobs) => Some(MessagePayload::JobsResult(jobs)),
                 Err(_err) => Some(MessagePayload::JobsResult(vec![])),
+            },
+            MessagePayload::ClaimJob {
+                executor_id,
+                job_id,
+            } => match self.backend.claim_job(job_id, executor_id).await {
+                Ok(job) => Some(MessagePayload::JobsResult(vec![job])),
+                Err(err) => {
+                    error!(job_id=?job_id, executor_id=?executor_id, err=?err, "Failed to claim job for executor");
+                    Some(MessagePayload::JobsResult(vec![]))
+                }
             },
             MessagePayload::ClaimJobs((_, end)) => {
                 match self


### PR DESCRIPTION
- Introduce `ClaimJob` which marks a single job as claimed
- Extends Job querying to support limit
- Now jobs are claimed from the scheduler after sending it to the executor instead of before