### PR TITLE
chore: provide `tracing` setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,25 @@ one sets the key. Don't add it to `Config` — that reopens the leak this ticket
 in `mate-cli/src/config.rs`. `Jail::create_file` does **not** create parent directories —
 `std::fs::create_dir_all` first for any nested path (e.g. `.config/mate/config.toml`).
 
+### M0-4 · Tracing setup (§11, done)
+
+`tracing-subscriber` (`env-filter` feature) + `tracing-appender` in `mate-cli/src/logging.rs`.
+`logging::init()` is called first thing in `main()`, before `Cli::parse()` / `config::load()`,
+and returns a `WorkerGuard` that must stay alive for the process lifetime (the writer is
+non-blocking; dropping the guard early loses buffered lines).
+
+Log file: `$XDG_STATE_HOME/mate/mate.log`, falling back to `~/.local/state/mate/mate.log`
+(mirrors the `XDG_CONFIG_HOME` pattern already used in `mate-cli/src/config.rs`). Level from
+`RUST_LOG`, default `info`. Writer is the file only — never stdout/stderr, in either `--plain`
+or TUI mode.
+
+`SessionId` / `AgentId` don't exist until the session manager (§5, M6); once they do, spans
+opened anywhere in `mate-core` should carry them as fields, per the plan's ordering note #1
+(§11) about adding enum/span keys early rather than retrofitting later.
+
+Covered by `crates/mate-cli/tests/tracing_stdout.rs` (spawns the built binary, asserts empty
+stdout and a populated log file) and unit tests in `logging.rs` for state-dir resolution.
+
 ### Testing conventions (§12)
 
 - Tools tested over `tempfile::TempDir` (`mate-tool-fs`) and `wiremock` (`mate-tool-http`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4748,10 +4748,12 @@ dependencies = [
  "mate-core",
  "mate-tui",
  "serde",
+ "tempfile",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-appender",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tokio-stream = "0.1.19"
 toml = "1.1.4"
 tracing = "0.1.44"
 tracing-appender = "0.2.5"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tui-textarea = "0.7.0"
 url = "2.5.8"
 wiremock = "0.6.5"

--- a/crates/mate-cli/Cargo.toml
+++ b/crates/mate-cli/Cargo.toml
@@ -18,6 +18,8 @@ tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 figment = { workspace = true, features = ["test"] }
+tempfile = { workspace = true }

--- a/crates/mate-cli/src/logging.rs
+++ b/crates/mate-cli/src/logging.rs
@@ -1,0 +1,91 @@
+//! Tracing setup (M0-4, §11 of `plan.md`): file-only logging to
+//! `$XDG_STATE_HOME/mate/mate.log` (or `~/.local/state/mate/mate.log`), level gated by
+//! `RUST_LOG` (default `info`). Never writes to stdout/stderr — the TUI owns the terminal,
+//! and `--plain` output must stay script-clean.
+//!
+//! `SessionId` / `AgentId` don't exist yet (they land with the session manager, §5), but every
+//! span opened from here forward is expected to carry them as fields once they do — cheaper to
+//! start that habit now than to retrofit every call site later.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::EnvFilter;
+
+/// `$XDG_STATE_HOME/mate` or `~/.local/state/mate`.
+fn state_dir() -> anyhow::Result<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_STATE_HOME") {
+        return Ok(PathBuf::from(xdg).join("mate"));
+    }
+    let home = std::env::var("HOME").context("HOME not set")?;
+    Ok(PathBuf::from(home).join(".local/state/mate"))
+}
+
+/// Initializes the global subscriber, writing exclusively to `mate.log`. Returns a guard that
+/// must be held for the process lifetime — dropping it early can lose buffered log lines,
+/// since the writer is non-blocking.
+pub fn init() -> anyhow::Result<WorkerGuard> {
+    let dir = state_dir()?;
+    fs::create_dir_all(&dir)
+        .with_context(|| format!("creating log directory {}", dir.display()))?;
+
+    let file_appender = tracing_appender::rolling::never(&dir, "mate.log");
+    let (writer, guard) = tracing_appender::non_blocking(file_appender);
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_ansi(false)
+        .with_writer(writer)
+        .init();
+
+    Ok(guard)
+}
+
+#[cfg(test)]
+// `Jail::expect_with` fixes its closure's error to `figment::Error`, which clippy flags as
+// large; not ours to box, since `Jail` decides the closure signature.
+#[allow(clippy::result_large_err)]
+mod tests {
+    use super::*;
+    use figment::Jail;
+
+    #[test]
+    fn prefers_xdg_state_home() {
+        Jail::expect_with(|jail| {
+            jail.clear_env();
+            let home = jail.directory().display().to_string();
+            jail.set_env("HOME", home);
+            jail.set_env("XDG_STATE_HOME", "/custom/state");
+
+            assert_eq!(state_dir().unwrap(), PathBuf::from("/custom/state/mate"));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn falls_back_to_home_dot_local_state() {
+        Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("HOME", "/home/tester");
+
+            assert_eq!(
+                state_dir().unwrap(),
+                PathBuf::from("/home/tester/.local/state/mate")
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn errors_without_home_or_xdg_state_home() {
+        Jail::expect_with(|jail| {
+            jail.clear_env();
+            assert!(state_dir().is_err());
+            Ok(())
+        });
+    }
+}

--- a/crates/mate-cli/src/main.rs
+++ b/crates/mate-cli/src/main.rs
@@ -4,13 +4,16 @@
 
 mod cli;
 mod config;
+mod logging;
 
 use clap::Parser;
 
 fn main() -> anyhow::Result<()> {
+    let _log_guard = logging::init()?;
+
     let args = cli::Cli::parse();
     let config = config::load(&args)?;
     tracing::debug!(model = %config.model, has_api_token = config::api_token().is_some(), "config loaded");
-    println!("mate");
+    tracing::info!("mate started");
     Ok(())
 }

--- a/crates/mate-cli/tests/tracing_stdout.rs
+++ b/crates/mate-cli/tests/tracing_stdout.rs
@@ -1,0 +1,31 @@
+//! M0-4 acceptance (§11, §15 of `plan.md`): a run produces zero stdout bytes — all tracing
+//! output lands in `mate.log`, never the terminal.
+
+use std::process::Command;
+
+#[test]
+fn run_produces_no_stdout_and_logs_to_file() {
+    let exe = env!("CARGO_BIN_EXE_mate");
+    let home = tempfile::tempdir().unwrap();
+
+    let output = Command::new(exe)
+        .env("HOME", home.path())
+        .env_remove("XDG_STATE_HOME")
+        .env("RUST_LOG", "trace")
+        .output()
+        .expect("failed to run mate");
+
+    assert!(
+        output.stdout.is_empty(),
+        "expected zero stdout bytes, got: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    let log_path = home.path().join(".local/state/mate/mate.log");
+    let log_contents = std::fs::read_to_string(&log_path)
+        .unwrap_or_else(|e| panic!("expected log file at {}: {e}", log_path.display()));
+    assert!(
+        log_contents.contains("mate started"),
+        "expected log to contain the startup line, got: {log_contents}"
+    );
+}


### PR DESCRIPTION
  - Workspace: add tracing-subscriber (env-filter feature), pin 0.3.23 matching Cargo.lock's transitive resolve.
  - mate-cli/src/logging.rs: init() builds file-only subscriber → $XDG_STATE_HOME/mate/mate.log (fallback ~/.local/state/mate/mate.log), level from RUST_LOG (default info), non-blocking writer, never
  stdout/stderr. Returns WorkerGuard caller must hold. Unit tests cover state-dir resolution (XDG override, HOME fallback, missing-both error).
  - main.rs: calls logging::init() first, drops the old unconditional println!("mate") (violated the "zero stdout" acceptance criterion) for tracing::info!("mate started").
  - crates/mate-cli/tests/tracing_stdout.rs: spawns built binary, asserts empty stdout and log file populated — matches ticket's stated acceptance check.
  - AGENTS.md: added M0-4 done entry so later agents don't redo it.
