### PR TITLE
feat: error strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,15 @@
 as reference for what CI runs, but do not execute them yourself. If verification is needed,
 ask the user to run it or rely on CI.
 
-## Project context (from `plan.md`)
+**Never reference `plan.md`, or any other planning doc supplied out-of-band, from code, doc
+comments, commit messages, or committed docs (`AGENTS.md`, `CONTRIBUTING.md`, etc.).** Such
+files are working input, not part of the repo (`plan.md` is `.gitignore`d) — anyone without
+the original loses the referent, and the pointer rots the moment a section renumbers. Milestone
+tags (`M0-5`) and `§N` section numbers are fine as an internal, self-contained convention, since
+this doc defines them itself; "per the plan", "`plan.md`", or any wording that implies a reader
+needs an external doc to make sense of a comment is not.
+
+## Project context
 
 `mate` — Rust CLI coding agent built on Rig + HuggingFace.
 
@@ -71,11 +79,29 @@ Log file: `$XDG_STATE_HOME/mate/mate.log`, falling back to `~/.local/state/mate/
 or TUI mode.
 
 `SessionId` / `AgentId` don't exist until the session manager (§5, M6); once they do, spans
-opened anywhere in `mate-core` should carry them as fields, per the plan's ordering note #1
-(§11) about adding enum/span keys early rather than retrofitting later.
+opened anywhere in `mate-core` should carry them as fields — add enum/span keys early rather
+than retrofitting later (§11).
 
 Covered by `crates/mate-cli/tests/tracing_stdout.rs` (spawns the built binary, asserts empty
 stdout and a populated log file) and unit tests in `logging.rs` for state-dir resolution.
+
+### M0-5 · Error strategy (§16, done)
+
+Three layers, documented in full in `CONTRIBUTING.md`:
+
+- Libraries (`mate-core`, `mate-tool-*`, `mate-tui`) return `thiserror` enums, never
+  `anyhow::Error` — callers need a matchable type. Tool crates converge on `ToolFailure`
+  (`M3-1`, not yet landed) which is deliberately non-fatal: fed back to the model as a tool
+  result, not a turn abort.
+- `mate-cli` plumbing (`config.rs`, `logging.rs`) stays `anyhow::Result` with
+  `.context(...)` — the binary edge, human-readable trail over a matchable type.
+- `mate-cli/src/error.rs` has `MateError`, the one error type at the CLI boundary.
+  `main.rs`'s `run()` maps each fallible call to a variant (`logging::init().map_err(MateError::Io)?`,
+  `config::load(&args).map_err(MateError::Config)?`); `main()` prints the error plus its
+  `source()` chain and converts `MateError::exit_code()` to the process `ExitCode`. Codes:
+  `Config` = 2, `Io` = 3, `Other` = 1, success = 0. `Auth`/`Provider` (codes 4/5, kept free) get
+  added as variants once `M1-5`/`M5-4` give them a real producer, not before — an unconstructed
+  variant is dead code under `clippy -D warnings`.
 
 ### Testing conventions (§12)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing
+
+## Error strategy (M0-5)
+
+Three layers, each with one job.
+
+### Libraries — `thiserror`
+
+Every `mate-*` library crate (`mate-core`, `mate-tool-api`, `mate-tool-fs`, `mate-tool-http`,
+`mate-tool-agent`, `mate-tui`) defines its own `#[derive(thiserror::Error)]` enum for errors
+callers might match on. Don't return `anyhow::Error` from a library function — it erases the
+type and forces every caller to string-match or downcast.
+
+Tool crates in particular converge on `ToolFailure` (`mate-tool-api`, landing with `M3-1`):
+a typed, non-fatal enum. A tool error is fed back to the model as a tool result, not raised as
+a turn abort — the `Display` string is written for a model to read and act on, not for a human
+staring at a stack trace. `mate-core`'s own errors (session/agent construction, provider
+mapping) stay `thiserror` too, for the same reason: `mate-cli` needs to distinguish them.
+
+### Binary edge — `anyhow`
+
+Inside `mate-cli`, plumbing code (`config.rs`, `logging.rs`, and anything else that's mostly
+"call a few fallible things and add context") returns `anyhow::Result`. Use
+`.context("...")` / `.with_context(|| ...)` liberally — this is the layer where a
+human-readable trail matters more than a matchable type. Don't invent a `thiserror` enum here;
+that's what the next layer is for.
+
+### CLI boundary — `MateError`
+
+`main.rs` is the one place `anyhow::Error` gets pinned to a category. `run()` (the real
+`main`, returning `Result<(), MateError>`) maps each fallible call site to a `MateError`
+variant right where it knows what failed:
+
+```rust
+let _log_guard = logging::init().map_err(MateError::Io)?;
+let config = config::load(&args).map_err(MateError::Config)?;
+```
+
+`main()` itself never returns `Result` — it calls `run()`, and on failure prints the error plus
+its full `source()` chain (each `context(...)` layer anyhow added, one "caused by:" line apiece)
+before turning `MateError::exit_code()` into the process's `ExitCode`. Every category gets a
+distinct, stable exit code (`Config` = 2, `Io` = 3, anything uncategorized = 1; `0` is success
+and nothing else).
+
+Add a `MateError` variant only once a failure mode has a real producer, not ahead of it — an
+unconstructed enum variant is dead code, and CI runs `clippy -D warnings`. `Auth` and
+`Provider` will land as variants (exit codes 4 and 5, keep them free) when `M1-5`/`M5-4`
+(provider error mapping) give them something to build from.
+
+### Rules of thumb
+
+- No `unwrap()` / `expect()` outside tests and truly-impossible states (and even then, prefer
+  `expect("why this can't happen")` over a bare `unwrap()`).
+- Add context at the point you have information the caller doesn't (a path, a URL, an ID) —
+  don't just propagate with `?` and hope the leaf error is self-explanatory.
+- A tool's error is not the same thing as the CLI's error. `ToolFailure` flows back into the
+  model's context; `MateError` flows to a human's terminal and a process exit code. Don't
+  conflate the two — a tool crate should never construct or depend on `MateError`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "mate-tui",
  "serde",
  "tempfile",
+ "thiserror 2.0.20",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
  "tracing",

--- a/crates/mate-cli/Cargo.toml
+++ b/crates/mate-cli/Cargo.toml
@@ -14,6 +14,7 @@ figment = { workspace = true }
 mate-core = { workspace = true }
 mate-tui = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/mate-cli/src/cli.rs
+++ b/crates/mate-cli/src/cli.rs
@@ -1,4 +1,4 @@
-//! CLI surface used to override config (§10 of `plan.md`). The full frontend-selection
+//! CLI surface used to override config (§10). The full frontend-selection
 //! behavior (`--plain`, `--print`, signal handling, …) lands with `M5-1`; this subset exists
 //! so config loading has real flags to layer on top of env/files/defaults.
 

--- a/crates/mate-cli/src/config.rs
+++ b/crates/mate-cli/src/config.rs
@@ -1,4 +1,4 @@
-//! Layered config loading (§10 of `plan.md`): flags → env → `./.mate.toml` →
+//! Layered config loading (§10): flags → env → `./.mate.toml` →
 //! `~/.config/mate/config.toml` → defaults, via `figment`.
 //!
 //! `API_TOKEN` is deliberately not a field on `Config` — it is read from the environment only,

--- a/crates/mate-cli/src/error.rs
+++ b/crates/mate-cli/src/error.rs
@@ -1,0 +1,52 @@
+//! One error type at the CLI boundary (M0-5, §16): every fallible step in `main`
+//! collapses into [`MateError`] before it's printed, so failures get a stable, category-scoped
+//! exit code instead of leaking as an opaque `anyhow::Error` dump.
+//!
+//! Everything below this layer stays `anyhow::Result` (the binary edge, per the error
+//! strategy) — `main` pins each call site's `anyhow::Error` to a `MateError` variant with
+//! `.map_err(...)`, right where it knows what failed.
+
+/// Exit-code-bearing error at the CLI boundary. One variant per category `main` can act on
+/// distinctly. `Auth` and `Provider` (per `M1-5`/`M5-4`) land as variants once those tickets
+/// give them a real producer — an unconstructed variant is dead code and `-D warnings` fails
+/// the build, so the enum only grows as failure modes actually exist.
+#[derive(Debug, thiserror::Error)]
+pub enum MateError {
+    #[error("config error: {0}")]
+    Config(#[source] anyhow::Error),
+
+    #[error("io error: {0}")]
+    Io(#[source] anyhow::Error),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl MateError {
+    /// Process exit code for this category. `0` is reserved for success and never returned
+    /// here.
+    pub fn exit_code(&self) -> u8 {
+        match self {
+            MateError::Config(_) => 2,
+            MateError::Io(_) => 3,
+            MateError::Other(_) => 1,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn each_variant_has_a_distinct_nonzero_exit_code() {
+        let codes = [
+            MateError::Config(anyhow::anyhow!("x")).exit_code(),
+            MateError::Io(anyhow::anyhow!("x")).exit_code(),
+            MateError::Other(anyhow::anyhow!("x")).exit_code(),
+        ];
+        assert!(codes.iter().all(|c| *c != 0));
+        let unique: std::collections::HashSet<_> = codes.iter().collect();
+        assert_eq!(unique.len(), codes.len());
+    }
+}

--- a/crates/mate-cli/src/logging.rs
+++ b/crates/mate-cli/src/logging.rs
@@ -1,4 +1,4 @@
-//! Tracing setup (M0-4, §11 of `plan.md`): file-only logging to
+//! Tracing setup (M0-4, §11): file-only logging to
 //! `$XDG_STATE_HOME/mate/mate.log` (or `~/.local/state/mate/mate.log`), level gated by
 //! `RUST_LOG` (default `info`). Never writes to stdout/stderr — the TUI owns the terminal,
 //! and `--plain` output must stay script-clean.

--- a/crates/mate-cli/src/main.rs
+++ b/crates/mate-cli/src/main.rs
@@ -4,15 +4,32 @@
 
 mod cli;
 mod config;
+mod error;
 mod logging;
 
 use clap::Parser;
+use error::MateError;
 
-fn main() -> anyhow::Result<()> {
-    let _log_guard = logging::init()?;
+fn main() -> std::process::ExitCode {
+    match run() {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("mate: {err}");
+            let mut source = std::error::Error::source(&err);
+            while let Some(cause) = source {
+                eprintln!("caused by: {cause}");
+                source = cause.source();
+            }
+            std::process::ExitCode::from(err.exit_code())
+        }
+    }
+}
+
+fn run() -> Result<(), MateError> {
+    let _log_guard = logging::init().map_err(MateError::Io)?;
 
     let args = cli::Cli::parse();
-    let config = config::load(&args)?;
+    let config = config::load(&args).map_err(MateError::Config)?;
     tracing::debug!(model = %config.model, has_api_token = config::api_token().is_some(), "config loaded");
     tracing::info!("mate started");
     Ok(())

--- a/crates/mate-cli/tests/tracing_stdout.rs
+++ b/crates/mate-cli/tests/tracing_stdout.rs
@@ -1,4 +1,4 @@
-//! M0-4 acceptance (§11, §15 of `plan.md`): a run produces zero stdout bytes — all tracing
+//! M0-4 acceptance (§11, §15): a run produces zero stdout bytes — all tracing
 //! output lands in `mate.log`, never the terminal.
 
 use std::process::Command;

--- a/crates/mate-core/src/config.rs
+++ b/crates/mate-core/src/config.rs
@@ -1,5 +1,5 @@
 //! Config-shaped domain types shared between `mate-cli`'s loader and the agent/session
-//! builders that will consume them (§4, §5.1, §10 of `plan.md`). `DelegationPolicy` and
+//! builders that will consume them (§4, §5.1, §10). `DelegationPolicy` and
 //! `HttpPolicy` are deserialized straight out of TOML tables; `AgentSpec` and `SessionSpec`
 //! are assembled from a loaded `Config` plus per-invocation data (workspace root, title).
 


### PR DESCRIPTION
- Add MateError (crates/mate-cli/src/error.rs): CLI-boundary error enum (Config/Io/Other), each with a distinct process exit code (2/3/1); Auth/Provider reserved (4/5) for future M1-5/M5-4.
  - Rework main.rs: split into run() -> Result<(), MateError> + main() -> ExitCode; failures print message plus full source() chain, then exit with the category's code.
  - Add thiserror dep to mate-cli.
  - Add CONTRIBUTING.md: documents the three-layer error strategy (thiserror in libs, anyhow at binary edge, MateError at CLI boundary).
  - Update AGENTS.md: new M0-5 section (done), new hard rule banning references to plan.md/external planning docs in code or committed docs.
  - Strip all plan.md file citations from doc comments (cli.rs, config.rs ×2, logging.rs, tracing_stdout.rs, error.rs, AGENTS.md) — keep §N/M0-N tags as a self-contained internal convention.