### PR TITLE
feat: support OpenAI as backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,6 +4774,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/mate-core/Cargo.toml
+++ b/crates/mate-core/Cargo.toml
@@ -17,3 +17,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+wiremock = { workspace = true }

--- a/crates/mate-core/src/agent.rs
+++ b/crates/mate-core/src/agent.rs
@@ -1,27 +1,47 @@
-//! `build_agent` (§4, `M1-2`): turns a [`Backend`] plus an [`AgentSpec`] into a Rig `Agent`.
+//! `build_agent` (§4, `M1-2`/`M1-3`): turns a [`Backend`] plus an [`AgentSpec`] into a Rig
+//! `Agent`.
 //!
-//! No tools yet — that lands with the tool crates in M4. This ticket wires the part of §4's
-//! builder that's available today: model, preamble, temperature, max_tokens. The same
-//! function builds root agents and subagents alike; a subagent is just an `AgentSpec` with a
-//! narrower preamble and `may_delegate: false`.
+//! `Agent<M>` is generic over the completion model, and `Backend`'s two provider paths
+//! (`M1-3`) produce distinct model types — a HuggingFace-native client and an
+//! OpenAI-compatible client are not interchangeable at the type level even though they're
+//! both driven by the same Chat Completions wire format. [`BuiltAgent`] carries that
+//! distinction forward instead of erasing it.
+//!
+//! No tools yet — that lands with the tool crates in M4. The same function builds root
+//! agents and subagents alike; a subagent is just an `AgentSpec` with a narrower preamble
+//! and `may_delegate: false`.
 
 use rig::agent::Agent;
 use rig::client::AgentClientExt;
-use rig::providers::huggingface;
+use rig::providers::{huggingface, openai};
 
 use crate::backend::Backend;
 use crate::config::AgentSpec;
 
-/// Builds a Rig agent against `backend`'s HuggingFace client, configured per `spec`.
-pub fn build_agent(
-    backend: &Backend,
-    spec: &AgentSpec,
-) -> Agent<huggingface::completion::CompletionModel> {
-    backend
-        .client()
-        .agent(&spec.model)
-        .preamble(&spec.preamble)
-        .temperature(spec.temperature)
-        .max_tokens(spec.max_tokens)
-        .build()
+/// A built agent — one variant per provider path a [`Backend`] can take (§4, `M1-3`).
+pub enum BuiltAgent {
+    HuggingFace(Agent<huggingface::completion::CompletionModel>),
+    OpenAiCompatible(Agent<openai::completion::CompletionModel>),
+}
+
+/// Builds a Rig agent against `backend`'s client, configured per `spec`.
+pub fn build_agent(backend: &Backend, spec: &AgentSpec) -> BuiltAgent {
+    match backend {
+        Backend::HuggingFace(client) => BuiltAgent::HuggingFace(
+            client
+                .agent(&spec.model)
+                .preamble(&spec.preamble)
+                .temperature(spec.temperature)
+                .max_tokens(spec.max_tokens)
+                .build(),
+        ),
+        Backend::OpenAiCompatible(client) => BuiltAgent::OpenAiCompatible(
+            client
+                .agent(&spec.model)
+                .preamble(&spec.preamble)
+                .temperature(spec.temperature)
+                .max_tokens(spec.max_tokens)
+                .build(),
+        ),
+    }
 }

--- a/crates/mate-core/src/backend.rs
+++ b/crates/mate-core/src/backend.rs
@@ -1,44 +1,84 @@
 //! `Backend` (§4): the process-wide, provider-backed client that every session's and
 //! subagent's `Agent` is built from — one auth setup, one pooled HTTP connection underneath.
 //!
-//! Rig's client machinery is itself generic (`client::Client<Ext, H>`, one `Ext` per
-//! provider); HuggingFace Inference Providers is the `Ext` this ticket wires up. `base_url`
-//! overrides and an OpenAI-compatible fallback path land as their own ticket — this type is
-//! named and shaped so that work slots in without a rename.
+//! Two provider paths, config-selected (`M1-3`):
+//!
+//! - [`Backend::huggingface`] — the default. Talks to HuggingFace Inference Providers
+//!   natively, optionally against a `base_url` override (a dedicated Inference Endpoint, or
+//!   a local server speaking HF's wire format).
+//! - [`Backend::openai_compatible`] — the escape hatch. Talks to any OpenAI-compatible chat
+//!   completions endpoint: the HF router's own OpenAI-compatible surface
+//!   ([`HF_ROUTER_OPENAI_BASE_URL`]), for the day Rig's native HuggingFace provider lags a
+//!   router change, or an arbitrary OpenAI-compatible server (local TGI/vLLM).
+//!
+//! Both variants share the same `Backend` type so callers elsewhere in `mate-core` (`M1-2`'s
+//! `build_agent`) don't need to know which path is live — see [`crate::agent::BuiltAgent`].
 
-use rig::providers::huggingface;
+use rig::client::VerifyClient;
+use rig::providers::{huggingface, openai};
 
-/// Shared across every session and subagent in the process (§5.3): one HuggingFace `Client`,
-/// one connection pool, one auth setup.
-pub struct Backend {
-    client: huggingface::Client,
+/// The HuggingFace router's OpenAI-compatible base URL — the default target for the
+/// [`Backend::openai_compatible`] fallback path.
+pub const HF_ROUTER_OPENAI_BASE_URL: &str = "https://router.huggingface.co/v1";
+
+/// Shared across every session and subagent in the process (§5.3): one provider client, one
+/// connection pool, one auth setup.
+pub enum Backend {
+    HuggingFace(huggingface::Client),
+    OpenAiCompatible(openai::CompletionsClient),
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum BackendError {
-    #[error("failed to build HuggingFace client: {0}")]
+    #[error("failed to build provider client: {0}")]
     Client(#[from] rig::http_client::Error),
 }
 
 impl Backend {
-    /// Builds the shared backend against HuggingFace Inference Providers.
+    /// Builds the shared backend against HuggingFace Inference Providers — the native path.
     ///
     /// `api_key` is the caller's `API_TOKEN` (read from the environment at the CLI boundary,
     /// never here — `mate-core` takes the value, not the env var). `sub_provider` selects the
     /// inference partner serving the model (`"together"`, `"fireworks"`, …); `None` or an
     /// unrecognized name falls back to HF's own `hf-inference`, never a hard error, since the
-    /// set of partners changes independently of `mate`.
-    pub fn new(api_key: impl AsRef<str>, sub_provider: Option<&str>) -> Result<Self, BackendError> {
-        let client = huggingface::Client::builder()
+    /// set of partners changes independently of `mate`. `base_url` overrides the router — a
+    /// dedicated Inference Endpoint, or a local server speaking HF's wire format.
+    pub fn huggingface(
+        api_key: impl AsRef<str>,
+        sub_provider: Option<&str>,
+        base_url: Option<&str>,
+    ) -> Result<Self, BackendError> {
+        let mut builder = huggingface::Client::builder()
             .api_key(api_key.as_ref())
-            .subprovider(parse_sub_provider(sub_provider))
-            .build()?;
-        Ok(Self { client })
+            .subprovider(parse_sub_provider(sub_provider));
+        if let Some(base_url) = base_url {
+            builder = builder.base_url(base_url);
+        }
+        Ok(Self::HuggingFace(builder.build()?))
     }
 
-    /// The underlying Rig client, for building agents against (§4, `M1-2`).
-    pub fn client(&self) -> &huggingface::Client {
-        &self.client
+    /// Builds the shared backend against an OpenAI-compatible endpoint — the fallback path.
+    /// Point `base_url` at [`HF_ROUTER_OPENAI_BASE_URL`] to reach the HuggingFace router's
+    /// OpenAI-compatible surface, or at an arbitrary OpenAI-compatible server (a local
+    /// TGI/vLLM instance).
+    pub fn openai_compatible(
+        api_key: impl AsRef<str>,
+        base_url: impl AsRef<str>,
+    ) -> Result<Self, BackendError> {
+        let client = openai::Client::builder()
+            .api_key(api_key.as_ref())
+            .base_url(base_url.as_ref())
+            .build()?
+            .completions_api();
+        Ok(Self::OpenAiCompatible(client))
+    }
+
+    /// Verifies the configured provider actually authenticates, regardless of path.
+    pub async fn verify(&self) -> Result<(), rig::client::VerifyError> {
+        match self {
+            Self::HuggingFace(client) => client.verify().await,
+            Self::OpenAiCompatible(client) => client.verify().await,
+        }
     }
 }
 
@@ -105,8 +145,26 @@ mod tests {
             Some("fireworks"),
             Some("a-future-partner"),
         ] {
-            Backend::new("dummy-key", sub_provider)
+            Backend::huggingface("dummy-key", sub_provider, None)
                 .expect("client construction never contacts the network");
         }
+    }
+
+    #[test]
+    fn builds_offline_with_a_huggingface_base_url_override() {
+        Backend::huggingface("dummy-key", None, Some("https://my-endpoint.example.com"))
+            .expect("base_url override never contacts the network");
+    }
+
+    #[test]
+    fn builds_offline_against_the_hf_router_openai_fallback() {
+        Backend::openai_compatible("dummy-key", HF_ROUTER_OPENAI_BASE_URL)
+            .expect("client construction never contacts the network");
+    }
+
+    #[test]
+    fn builds_offline_against_an_arbitrary_openai_compatible_base_url() {
+        Backend::openai_compatible("dummy-key", "http://127.0.0.1:8080/v1")
+            .expect("client construction never contacts the network");
     }
 }

--- a/crates/mate-core/tests/hf_backend.rs
+++ b/crates/mate-core/tests/hf_backend.rs
@@ -3,16 +3,15 @@
 //! `#[ignore]`d — run manually, never in CI.
 
 use mate_core::backend::Backend;
-use rig::client::VerifyClient;
 
 #[tokio::test]
 #[ignore = "hits the live HuggingFace router; run manually with API_TOKEN set"]
 async fn reaches_the_router() {
     let token = std::env::var("API_TOKEN").expect("set API_TOKEN to run this test");
-    let backend = Backend::new(token, None).expect("failed to build HuggingFace client");
+    let backend =
+        Backend::huggingface(token, None, None).expect("failed to build HuggingFace client");
 
     backend
-        .client()
         .verify()
         .await
         .expect("HuggingFace router rejected the token");

--- a/crates/mate-core/tests/openai_fallback.rs
+++ b/crates/mate-core/tests/openai_fallback.rs
@@ -1,0 +1,59 @@
+//! Exercises the OpenAI-compatible fallback path (§4, `M1-3`) end to end: builds a
+//! `Backend::openai_compatible` pointed at a local stub server, builds an agent from it, and
+//! confirms a prompt actually round-trips through the OpenAI-shaped `/chat/completions` wire
+//! format rather than just constructing without error.
+
+use mate_core::agent::{BuiltAgent, build_agent};
+use mate_core::backend::Backend;
+use mate_core::config::{AgentSpec, DelegationPolicy, HttpPolicy};
+use rig::prelude::*;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn stub_agent_spec() -> AgentSpec {
+    AgentSpec {
+        model: "stub-model".to_string(),
+        sub_provider: None,
+        base_url: None,
+        preamble: "you are a test agent".to_string(),
+        temperature: 0.0,
+        max_tokens: 64,
+        http: HttpPolicy::default(),
+        may_delegate: false,
+        delegation: DelegationPolicy::default(),
+    }
+}
+
+#[tokio::test]
+async fn openai_compatible_fallback_round_trips_through_a_stub_server() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "chatcmpl-stub",
+            "model": "stub-model",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "pong from stub" },
+                "finish_reason": "stop"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let backend = Backend::openai_compatible("dummy-key", server.uri())
+        .expect("failed to build the OpenAI-compatible client");
+
+    let agent = match build_agent(&backend, &stub_agent_spec()) {
+        BuiltAgent::OpenAiCompatible(agent) => agent,
+        BuiltAgent::HuggingFace(_) => panic!("expected the OpenAiCompatible variant"),
+    };
+
+    let reply = agent
+        .prompt("ping")
+        .await
+        .expect("prompt against the stub server failed");
+
+    assert_eq!(reply, "pong from stub");
+}


### PR DESCRIPTION
Provides support for multiple backends, now HuggingFace and OpenAI compatible models are supported.